### PR TITLE
[ADD] 카메라 결과 화면

### DIFF
--- a/Samplero/Samplero.xcodeproj/project.pbxproj
+++ b/Samplero/Samplero.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		35084E4C28F02A9300621C0D /* ImageLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35084E4B28F02A9300621C0D /* ImageLiteral.swift */; };
 		CE1052E128F279DB00503ECF /* CameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1052E028F279DB00503ECF /* CameraViewController.swift */; };
 		CE13B6C728F1600B00216EB2 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = CE13B6C628F1600B00216EB2 /* .swiftlint.yml */; };
+		CE9C460828F4595900890821 /* TakenPictureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9C460728F4595900890821 /* TakenPictureViewController.swift */; };
 		CEF76BD328EE77C0003D1F49 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF76BD228EE77C0003D1F49 /* AppDelegate.swift */; };
 		CEF76BD528EE77C0003D1F49 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF76BD428EE77C0003D1F49 /* SceneDelegate.swift */; };
 		CEF76BD728EE77C0003D1F49 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF76BD628EE77C0003D1F49 /* MainViewController.swift */; };
@@ -60,6 +61,7 @@
 		35084E4B28F02A9300621C0D /* ImageLiteral.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageLiteral.swift; sourceTree = "<group>"; };
 		CE1052E028F279DB00503ECF /* CameraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewController.swift; sourceTree = "<group>"; };
 		CE13B6C628F1600B00216EB2 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		CE9C460728F4595900890821 /* TakenPictureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakenPictureViewController.swift; sourceTree = "<group>"; };
 		CEF76BCF28EE77C0003D1F49 /* Samplero.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Samplero.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEF76BD228EE77C0003D1F49 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CEF76BD428EE77C0003D1F49 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 		21ED8C6B28EFC64C0074C9A3 /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				CE9C460628F4592E00890821 /* TakenPicture */,
 				CE1052DD28F279A900503ECF /* Camera */,
 				21ED8C6C28EFC6510074C9A3 /* Main */,
 			);
@@ -259,6 +262,14 @@
 				CE1052E028F279DB00503ECF /* CameraViewController.swift */,
 			);
 			path = Camera;
+			sourceTree = "<group>";
+		};
+		CE9C460628F4592E00890821 /* TakenPicture */ = {
+			isa = PBXGroup;
+			children = (
+				CE9C460728F4595900890821 /* TakenPictureViewController.swift */,
+			);
+			path = TakenPicture;
 			sourceTree = "<group>";
 		};
 		CEF76BC628EE77C0003D1F49 = {
@@ -491,6 +502,7 @@
 				21ED8C8028EFC7990074C9A3 /* BaseTableViewCell.swift in Sources */,
 				21ED8C7B28EFC77B0074C9A3 /* NSObject+Extension.swift in Sources */,
 				21ED8C7F28EFC7990074C9A3 /* BaseViewController.swift in Sources */,
+				CE9C460828F4595900890821 /* TakenPictureViewController.swift in Sources */,
 				35084E4A28F0292C00621C0D /* Color+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -253,13 +253,12 @@ extension CameraViewController: AVCapturePhotoCaptureDelegate {
         guard let data = photo.fileDataRepresentation() else {
             return
         }
-        let image = UIImage(data: data)
+        
+        let takenPictureViewController = TakenPictureViewController()
+        takenPictureViewController.configPictureImage(image: UIImage(data: data) ?? UIImage())
+        takenPictureViewController.modalPresentationStyle = .overFullScreen
+        self.present(takenPictureViewController, animated: true)
         
         session?.stopRunning()
-        
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFill
-        imageView.frame = view.bounds
-        view.addSubview(imageView)
     }
 }

--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -256,6 +256,7 @@ extension CameraViewController: AVCapturePhotoCaptureDelegate {
         
         let takenPictureViewController = TakenPictureViewController()
         takenPictureViewController.configPictureImage(image: UIImage(data: data) ?? UIImage())
+        takenPictureViewController.setSession(session: &session)
         takenPictureViewController.modalPresentationStyle = .overFullScreen
         self.present(takenPictureViewController, animated: true)
         

--- a/Samplero/Samplero/Screen/TakenPicture/TakenPictureViewController.swift
+++ b/Samplero/Samplero/Screen/TakenPicture/TakenPictureViewController.swift
@@ -5,6 +5,7 @@
 //  Created by JiwKang on 2022/10/10.
 //
 
+import AVFoundation
 import UIKit
 
 import RxCocoa
@@ -14,6 +15,8 @@ import SnapKit
 class TakenPictureViewController: BaseViewController {
     
     // MARK: - Properties
+    
+    var session: AVCaptureSession?
     
     // Rx
     var disposeBag = DisposeBag()
@@ -107,6 +110,10 @@ class TakenPictureViewController: BaseViewController {
     
     // MARK: - Func
     
+    func setSession(session: inout AVCaptureSession?) {
+        self.session = session
+    }
+    
     func configPictureImage(image: UIImage) {
         takenPictureImageView.image = image
     }
@@ -116,6 +123,9 @@ class TakenPictureViewController: BaseViewController {
             print("clicked retake picture button")
             self.dismiss(animated: true, completion: nil)
             
+            DispatchQueue.global().async {
+                self.session?.startRunning()
+            }
         }.disposed(by: disposeBag)
         
         nextButton.rx.tap.bind {

--- a/Samplero/Samplero/Screen/TakenPicture/TakenPictureViewController.swift
+++ b/Samplero/Samplero/Screen/TakenPicture/TakenPictureViewController.swift
@@ -1,0 +1,126 @@
+//
+//  TakenPictureViewController.swift
+//  Samplero
+//
+//  Created by JiwKang on 2022/10/10.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+class TakenPictureViewController: BaseViewController {
+    
+    // MARK: - Properties
+    
+    // Rx
+    var disposeBag = DisposeBag()
+    
+    // Picture view
+    private let takenPictureImageView: UIImageView = {
+        let imageView: UIImageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        return imageView
+    }()
+    
+    // Top Drawer
+    private let topDrawer: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = .black
+        return view
+    }()
+    
+    // Bottom Drawer
+    private let bottomDrawer: UIView = {
+        let view: UIView = UIView()
+        view.backgroundColor = .black
+        return view
+    }()
+    
+    // Retake Button
+    private let retakeButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setTitle("다시찍기", for: .normal)
+        button.titleLabel?.textColor = .white
+        button.titleLabel?.font = .boldSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize)
+        return button
+    }()
+    
+    // Next Button
+    private let nextButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setTitle("다음", for: .normal)
+        button.titleLabel?.textColor = .white
+        button.titleLabel?.font = .boldSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize)
+        return button
+    }()
+    
+    // MARK: - Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        addTargets()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        disposeBag = DisposeBag()
+    }
+    
+    override func render() {
+        view.addSubview(takenPictureImageView)
+        
+        view.addSubview(topDrawer)
+        topDrawer.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview()
+            make.width.equalToSuperview()
+            make.height.equalTo(UIScreen.main.bounds.height / 6.975)
+        }
+        
+        view.addSubview(bottomDrawer)
+        bottomDrawer.snp.makeConstraints { make in
+            make.bottom.leading.equalToSuperview()
+            make.width.equalToSuperview()
+            make.height.equalTo(UIScreen.main.bounds.height / 4.157)
+        }
+        
+        takenPictureImageView.snp.makeConstraints { make in
+            make.top.equalTo(topDrawer.snp.bottom)
+            make.bottom.equalTo(bottomDrawer.snp.top)
+            make.leading.trailing.equalToSuperview()
+        }
+        
+        view.addSubview(retakeButton)
+        retakeButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(24)
+            make.bottom.equalToSuperview().inset(44)
+        }
+        
+        view.addSubview(nextButton)
+        nextButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(24)
+            make.bottom.equalToSuperview().inset(44)
+        }
+    }
+    
+    // MARK: - Func
+    
+    func configPictureImage(image: UIImage) {
+        takenPictureImageView.image = image
+    }
+    
+    func addTargets() {
+        retakeButton.rx.tap.bind {
+            print("clicked retake picture button")
+            self.dismiss(animated: true, completion: nil)
+            
+        }.disposed(by: disposeBag)
+        
+        nextButton.rx.tap.bind {
+            // TODO: go next
+            print("clicked next button")
+        }.disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
close #17 카메라 결과 화면 추가

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
* 촬영한 사진을 확인하는 ImageView 추가
* 다시찍기를 위한 '다시찍기' 버튼 추가
* 찍은 후 다음 프로세스로 넘어가기 위한 '다음' 버튼 추가

__스크린샷__
![카메라 결과화면 - NotFixed](https://user-images.githubusercontent.com/56468120/194897891-e095f958-8830-4c29-8e86-fa694d988689.png)


## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
1. 사진을 찍은 경우 다음과 같이 session을 관리하는 코드가 존재합니다. 
    ```swift
    var session: AVCaptureSession = AVCaptureSession()
    session.startRunning() // 촬영할 수 있도록 카메라 세션 시작
    session.stopRunning() // 촬영을 완료하여 카메라 세션 종료
    ```
    CameraViewController에서 사진을 촬영하면 TakenPictureViewController로 이동하는데 이때 다시 찍기를 누르는 경우 session을 다시 시작하는 코드가 필요하여 session을 다음과 같이 CameraViewController에서 TakenPictureViewController로 넘겨주는 코드를 추가하였습니다.

    __TakenPictureViewController.swift__
    ```swift
    func setSession(session: inout AVCaptureSession) {
        self.session = session
    }
    ```

    __CameraViewController.swift__
    ```swift
    let takenPictureViewController: TakenPictureViewController()
    takenPictureViewController.setSession(session: &session)
    ```

이와 같은 방식으로 객체를 넘겨주는 것은 MVVM에 어긋나는 방식일까요?
만약 그렇다면 대안을 알려주시면 감사하겠습니다.
아니라면 그냥 이렇게 사용하도록 하겠습니다.

## ⁴/₄ 다음으로 진행될 작업
 - [ ] TakenPictureViewController의 다음 버튼 기능 추가

