### PR TITLE
[FEAT] 라이브러리에서 사진 가져오기

### DIFF
--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -5,8 +5,8 @@
 //  Created by JiwKang on 2022/10/09.
 //
 
-import UIKit
 import AVFoundation
+import UIKit
 
 import SnapKit
 import RxSwift

--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -181,8 +181,11 @@ class CameraViewController: BaseViewController {
         }.disposed(by: disposeBag)
 
         bringPhotoButton.rx.tap.bind {
-            // TODO: bring photo from library
-            print("clicked bring photo from library")
+            let imagePickerController = UIImagePickerController()
+            imagePickerController.sourceType = .photoLibrary
+            imagePickerController.delegate = self
+            imagePickerController.allowsEditing = false
+            self.present(imagePickerController, animated: true)
         }.disposed(by: disposeBag)
         
         photoHistoryButton.rx.tap.bind {
@@ -261,5 +264,20 @@ extension CameraViewController: AVCapturePhotoCaptureDelegate {
         imageView.contentMode = .scaleAspectFill
         imageView.frame = view.bounds
         view.addSubview(imageView)
+    }
+}
+
+extension CameraViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        if let selectedImage = info[UIImagePickerController.InfoKey(rawValue: "UIImagePickerControllerOriginalImage")] as? UIImage {
+            // TODO: TakenPictureViewController present with selectedImage
+            print("got image from library", "\(selectedImage)")
+        }
+        
+        picker.dismiss(animated: true, completion: nil)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
close #19 [Feature] 라이브러리에서 사진 가져오기 기능 추가

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
* 라이브러리에서 사진을 가져오는 기능을 UIImagePickerController를 이용하여 구현하였습니다.

![Watch the video](https://user-images.githubusercontent.com/56468120/195041543-ce652cb7-7c14-4283-a114-8464b82363d4.mp4)

## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
1. iOS 15.0 이후 나온 PHPickerViewController를 사용하려 했으나 프로젝트가 14.0부터 지원하기 때문에 UIImagePickerController를 사용하였습니다. (*UIImagePickerController는 Deprecated되지 않음*)
15.0 이전, 이후를 각각 UIImagePickerController, PHPickerViewController로 구현을 할까요? 아니면 그냥 UIImagePickerController만 사용할까요?

## ⁴/₄ 다음으로 진행될 작업
 - [ ] CameraView 모든 화면 전환 처리

