### PR TITLE
[UI] CameraView 화면 전환 연결

### DIFF
--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -102,11 +102,6 @@ class CameraViewController: BaseViewController {
         addTargets()
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(true)
-        disposeBag = DisposeBag()
-    }
-    
     override func render() {
         view.layer.addSublayer(previewLayer)
         previewLayer.frame = view.bounds

--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -261,9 +261,12 @@ extension CameraViewController: AVCapturePhotoCaptureDelegate {
         takenPictureViewController.configPictureImage(image: UIImage(data: data) ?? UIImage())
         takenPictureViewController.modalPresentationStyle = .overFullScreen
         takenPictureViewController.rx.retake
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] in
+            .observe(on: ConcurrentDispatchQueueScheduler(qos: .background))
+            .map { [weak self] in
                 self?.session?.startRunning()
+            }
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: {
                 takenPictureViewController.dismiss(animated: true)
             }).disposed(by: disposeBag)
         self.present(takenPictureViewController, animated: true)

--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -96,6 +96,11 @@ class CameraViewController: BaseViewController {
     
     // MARK: - Life Cycle
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = true
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         checkCameraPermissions()
@@ -160,6 +165,7 @@ class CameraViewController: BaseViewController {
         imageView.layer.zPosition = -1
         view.addSubview(imageView)
         #endif
+        
         view.backgroundColor = .black
         navigationItem.backButtonTitle = "카메라"
     }

--- a/Samplero/Samplero/Screen/EstimateHistory/EstimateHistoryViewController.swift
+++ b/Samplero/Samplero/Screen/EstimateHistory/EstimateHistoryViewController.swift
@@ -29,6 +29,10 @@ class EstimateHistoryViewController: BaseViewController {
     }()
     
     // MARK: - Life Cycle
+    
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.isNavigationBarHidden = false
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
close #32 [UI]: CameraView에 화면 전환 연결

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
CameraViewController의 화면 전환을 연결하였습니다.
* 상단 사진 불러오기 버튼 클릭을 통해 ImagePickerViewController 표시

![Watch the video](https://user-images.githubusercontent.com/56468120/195270029-34e8bac3-7a72-4c28-8fb6-a0e3d5df2051.MP4)

* 좌 하단 이미지 버튼 클릭을 통해 견적 내역 화면으로 이동

![Watch the video](https://user-images.githubusercontent.com/56468120/195271268-ef656a10-1175-4cf5-807f-b342eb428998.mov)

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 각 화면 DB에 필요한 작업 수행

## ⁴/₄ PR 포인트
* md 비디오 사이즈 조절할 줄 아시는 분~