### PR TITLE
[ADD] UIViewController+Alert Extension 추가

### DIFF
--- a/Samplero/Samplero.xcodeproj/project.pbxproj
+++ b/Samplero/Samplero.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		210CC67F28F26FD5008191A9 /* BottomSheetTransitioningDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210CC67E28F26FD5008191A9 /* BottomSheetTransitioningDelegate.swift */; };
 		210CC68128F26FEF008191A9 /* BottomSheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210CC68028F26FEF008191A9 /* BottomSheetController.swift */; };
 		210CC68328F2700C008191A9 /* GetAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210CC68228F2700C008191A9 /* GetAreaViewController.swift */; };
+		2164307A28F69FA600443A1B /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164307928F69FA600443A1B /* UIViewController+Alert.swift */; };
 		216CA5BA28F56433008C09C7 /* CustomGetSizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216CA5B928F56433008C09C7 /* CustomGetSizeView.swift */; };
 		2195EA0C28F2E7C800299B39 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2195EA0B28F2E7C800299B39 /* UIViewController+Extension.swift */; };
 		21C81DA328F45447000E89DA /* AreaTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81DA228F45447000E89DA /* AreaTestViewController.swift */; };
@@ -39,18 +40,7 @@
 		355CB86D28F2EFEF001A5731 /* EstimateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB86C28F2EFEF001A5731 /* EstimateViewModel.swift */; };
 		355CB87028F2F716001A5731 /* ViewModelBindableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB86E28F2F716001A5731 /* ViewModelBindableType.swift */; };
 		355CB87128F2F716001A5731 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB86F28F2F716001A5731 /* ViewModelType.swift */; };
-		CE13B6C728F1600B00216EB2 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = CE13B6C628F1600B00216EB2 /* .swiftlint.yml */; };
 		CE1052E128F279DB00503ECF /* CameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1052E028F279DB00503ECF /* CameraViewController.swift */; };
-		35109D3328F551F500EA6F8F /* CGSize+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35109D3228F551F500EA6F8F /* CGSize+Extension.swift */; };
-		355CB85428F0843D001A5731 /* EstimateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB85328F0843D001A5731 /* EstimateViewController.swift */; };
-		355CB85B28F09B06001A5731 /* SampleDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB85A28F09B06001A5731 /* SampleDetailView.swift */; };
-		355CB85D28F1D15B001A5731 /* CommonStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB85C28F1D15B001A5731 /* CommonStackView.swift */; };
-		355CB85F28F1D5DA001A5731 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB85E28F1D5DA001A5731 /* Sample.swift */; };
-		355CB86128F295A0001A5731 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB86028F295A0001A5731 /* MockData.swift */; };
-		355CB86828F29F57001A5731 /* SampleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB86728F29F57001A5731 /* SampleCollectionViewCell.swift */; };
-		355CB86D28F2EFEF001A5731 /* EstimateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB86C28F2EFEF001A5731 /* EstimateViewModel.swift */; };
-		355CB87028F2F716001A5731 /* ViewModelBindableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB86E28F2F716001A5731 /* ViewModelBindableType.swift */; };
-		355CB87128F2F716001A5731 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355CB86F28F2F716001A5731 /* ViewModelType.swift */; };
 		CE13B6C728F1600B00216EB2 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = CE13B6C628F1600B00216EB2 /* .swiftlint.yml */; };
 		CE9C460828F4595900890821 /* TakenPictureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9C460728F4595900890821 /* TakenPictureViewController.swift */; };
 		CEF76BD328EE77C0003D1F49 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF76BD228EE77C0003D1F49 /* AppDelegate.swift */; };
@@ -93,6 +83,7 @@
 		210CC67E28F26FD5008191A9 /* BottomSheetTransitioningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetTransitioningDelegate.swift; sourceTree = "<group>"; };
 		210CC68028F26FEF008191A9 /* BottomSheetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetController.swift; sourceTree = "<group>"; };
 		210CC68228F2700C008191A9 /* GetAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAreaViewController.swift; sourceTree = "<group>"; };
+		2164307928F69FA600443A1B /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		216CA5B928F56433008C09C7 /* CustomGetSizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomGetSizeView.swift; sourceTree = "<group>"; };
 		2195EA0B28F2E7C800299B39 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		21C81DA228F45447000E89DA /* AreaTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaTestViewController.swift; sourceTree = "<group>"; };
@@ -112,18 +103,7 @@
 		355CB86C28F2EFEF001A5731 /* EstimateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EstimateViewModel.swift; sourceTree = "<group>"; };
 		355CB86E28F2F716001A5731 /* ViewModelBindableType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelBindableType.swift; sourceTree = "<group>"; };
 		355CB86F28F2F716001A5731 /* ViewModelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
-		CE13B6C628F1600B00216EB2 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		CE1052E028F279DB00503ECF /* CameraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewController.swift; sourceTree = "<group>"; };
-		35109D3228F551F500EA6F8F /* CGSize+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Extension.swift"; sourceTree = "<group>"; };
-		355CB85328F0843D001A5731 /* EstimateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EstimateViewController.swift; sourceTree = "<group>"; };
-		355CB85A28F09B06001A5731 /* SampleDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleDetailView.swift; sourceTree = "<group>"; };
-		355CB85C28F1D15B001A5731 /* CommonStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonStackView.swift; sourceTree = "<group>"; };
-		355CB85E28F1D5DA001A5731 /* Sample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
-		355CB86028F295A0001A5731 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
-		355CB86728F29F57001A5731 /* SampleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleCollectionViewCell.swift; sourceTree = "<group>"; };
-		355CB86C28F2EFEF001A5731 /* EstimateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EstimateViewModel.swift; sourceTree = "<group>"; };
-		355CB86E28F2F716001A5731 /* ViewModelBindableType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelBindableType.swift; sourceTree = "<group>"; };
-		355CB86F28F2F716001A5731 /* ViewModelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelType.swift; sourceTree = "<group>"; };
 		CE13B6C628F1600B00216EB2 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		CE9C460728F4595900890821 /* TakenPictureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakenPictureViewController.swift; sourceTree = "<group>"; };
 		CEF76BCF28EE77C0003D1F49 /* Samplero.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Samplero.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -197,8 +177,6 @@
 		21ED8C6828EFC63A0074C9A3 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				355CB86028F295A0001A5731 /* MockData.swift */,
-				355CB85E28F1D5DA001A5731 /* Sample.swift */,
 				CEFFE78628F3D0E5007A7842 /* EstimateHistory.swift */,
 				355CB86028F295A0001A5731 /* MockData.swift */,
 				355CB85E28F1D5DA001A5731 /* Sample.swift */,
@@ -225,7 +203,6 @@
 			isa = PBXGroup;
 			children = (
 				CE9C460628F4592E00890821 /* TakenPicture */,
-				355CB85228F08427001A5731 /* Estimate */,
 				CE1052DD28F279A900503ECF /* Camera */,
 				210CC68628F29D71008191A9 /* Calculation */,
 				CEFFE77828F3C5BE007A7842 /* EstimateHistory */,
@@ -318,6 +295,7 @@
 				2195EA0B28F2E7C800299B39 /* UIViewController+Extension.swift */,
 				CEFFE77E28F3C7D4007A7842 /* UICollectionView+Extension.swift */,
 				35109D3228F551F500EA6F8F /* CGSize+Extension.swift */,
+				2164307928F69FA600443A1B /* UIViewController+Alert.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -405,42 +383,6 @@
 				CE9C460728F4595900890821 /* TakenPictureViewController.swift */,
 			);
 			path = TakenPicture;
-			sourceTree = "<group>";
-		};
-		355CB85228F08427001A5731 /* Estimate */ = {
-			isa = PBXGroup;
-			children = (
-				355CB85728F08F7A001A5731 /* View */,
-				355CB85328F0843D001A5731 /* EstimateViewController.swift */,
-				355CB86B28F2EFDC001A5731 /* ViewModel */,
-			);
-			path = Estimate;
-			sourceTree = "<group>";
-		};
-		355CB85728F08F7A001A5731 /* View */ = {
-			isa = PBXGroup;
-			children = (
-				355CB86228F29E89001A5731 /* cell */,
-				355CB85A28F09B06001A5731 /* SampleDetailView.swift */,
-				355CB85C28F1D15B001A5731 /* CommonStackView.swift */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
-		355CB86228F29E89001A5731 /* cell */ = {
-			isa = PBXGroup;
-			children = (
-				355CB86728F29F57001A5731 /* SampleCollectionViewCell.swift */,
-			);
-			path = cell;
-			sourceTree = "<group>";
-		};
-		355CB86B28F2EFDC001A5731 /* ViewModel */ = {
-			isa = PBXGroup;
-			children = (
-				355CB86C28F2EFEF001A5731 /* EstimateViewModel.swift */,
-			);
-			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		CEF76BC628EE77C0003D1F49 = {
@@ -733,6 +675,7 @@
 				210CC68128F26FEF008191A9 /* BottomSheetController.swift in Sources */,
 				210CC67D28F26FBD008191A9 /* BottomSheetPresentationController.swift in Sources */,
 				355CB87128F2F716001A5731 /* ViewModelType.swift in Sources */,
+				2164307A28F69FA600443A1B /* UIViewController+Alert.swift in Sources */,
 				35084E4A28F0292C00621C0D /* Color+Extension.swift in Sources */,
 				CEFFE77D28F3C689007A7842 /* EstimateHistoryCollectionViewCell.swift in Sources */,
 			);

--- a/Samplero/Samplero/Global/Extension/UIViewController+Alert.swift
+++ b/Samplero/Samplero/Global/Extension/UIViewController+Alert.swift
@@ -10,13 +10,13 @@ import UIKit
 extension UIViewController {
     func makeAlert(title: String,
                    message: String,
-                   okAction: ((UIAlertAction) -> Void)? = nil,
+                   okayAction: ((UIAlertAction) -> Void)? = nil,
                    completion : (() -> Void)? = nil) {
         let alertViewController = UIAlertController(title: title,
                                                     message: message,
                                                     preferredStyle: .alert)
-        let okAction = UIAlertAction(title: "확인", style: .default, handler: okAction)
-        alertViewController.addAction(okAction)
+        let okayAction = UIAlertAction(title: "확인", style: .default, handler: okayAction)
+        alertViewController.addAction(okayAction)
         
         self.present(alertViewController, animated: true, completion: completion)
     }
@@ -25,7 +25,7 @@ extension UIViewController {
                           message: String,
                           okTitle: String = "확인",
                           cancelTitle: String = "취소",
-                          okAction: ((UIAlertAction) -> Void)?,
+                          okayAction: ((UIAlertAction) -> Void)?,
                           cancelAction: ((UIAlertAction) -> Void)? = nil,
                           completion : (() -> Void)? = nil) {
         let generator = UIImpactFeedbackGenerator(style: .medium)
@@ -40,10 +40,10 @@ extension UIViewController {
                                          handler: cancelAction)
         alertViewController.addAction(cancelAction)
         
-        let okAction = UIAlertAction(title: okTitle,
+        let okayAction = UIAlertAction(title: okTitle,
                                      style: .destructive,
-                                     handler: okAction)
-        alertViewController.addAction(okAction)
+                                     handler: okayAction)
+        alertViewController.addAction(okayAction)
         
         self.present(alertViewController, animated: true, completion: completion)
     }

--- a/Samplero/Samplero/Global/Extension/UIViewController+Alert.swift
+++ b/Samplero/Samplero/Global/Extension/UIViewController+Alert.swift
@@ -1,0 +1,69 @@
+//
+//  UIViewController+Alert.swift
+//  Samplero
+//
+//  Created by Minkyeong Ko on 2022/10/12.
+//
+
+import UIKit
+
+extension UIViewController {
+    func makeAlert(title: String,
+                   message: String,
+                   okAction: ((UIAlertAction) -> Void)? = nil,
+                   completion : (() -> Void)? = nil) {
+        let alertViewController = UIAlertController(title: title,
+                                                    message: message,
+                                                    preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default, handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+    
+    func makeRequestAlert(title: String,
+                          message: String,
+                          okTitle: String = "확인",
+                          cancelTitle: String = "취소",
+                          okAction: ((UIAlertAction) -> Void)?,
+                          cancelAction: ((UIAlertAction) -> Void)? = nil,
+                          completion : (() -> Void)? = nil) {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        
+        let alertViewController = UIAlertController(title: title,
+                                                    message: message,
+                                                    preferredStyle: .alert)
+        
+        let cancelAction = UIAlertAction(title: cancelTitle,
+                                         style: .default,
+                                         handler: cancelAction)
+        alertViewController.addAction(cancelAction)
+        
+        let okAction = UIAlertAction(title: okTitle,
+                                     style: .destructive,
+                                     handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+    
+    func makeActionSheet(title: String? = nil,
+                         message: String? = nil,
+                         actionTitles:[String?],
+                         actionStyle:[UIAlertAction.Style],
+                         actions:[((UIAlertAction) -> Void)?]) {
+        let alert = UIAlertController(title: title,
+                                      message: message,
+                                      preferredStyle: .actionSheet)
+        
+        for (index, title) in actionTitles.enumerated() {
+            let action = UIAlertAction(title: title,
+                                       style: actionStyle[index],
+                                       handler: actions[index])
+            alert.addAction(action)
+        }
+        
+        self.present(alert, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #29 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
<img width="260" src="https://user-images.githubusercontent.com/78426896/195274649-88c63862-00fa-4931-b6eb-657e60db422c.png" />
- UIViewController+Alert Extension을 추가하였습니다.


## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
- 다른 프로젝트에서 사용하던 파일을 가져왔습니다. makeAlert와 makeRequestAlert는 저희 프로젝트에서도 사용할 것 같아서 두면 좋을 것 같고 actionSheet는 사용하지 않으면 삭제하려 하는데 다들 어떠신지 궁금합니다!

## ⁴/₄ 다음으로 진행될 작업
- [ ] 필요하면 파일 수정

