### PR TITLE
[ADD] Toast UI 구현

### DIFF
--- a/Samplero/Samplero.xcodeproj/project.pbxproj
+++ b/Samplero/Samplero.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2164307428F693F500443A1B /* CustomCheckbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164307328F693F500443A1B /* CustomCheckbox.swift */; };
 		2164307A28F69FA600443A1B /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164307928F69FA600443A1B /* UIViewController+Alert.swift */; };
 		216CA5BA28F56433008C09C7 /* CustomGetSizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216CA5B928F56433008C09C7 /* CustomGetSizeView.swift */; };
+		2188F2F928F7B434005BC322 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188F2F828F7B434005BC322 /* PaddedLabel.swift */; };
 		2195EA0C28F2E7C800299B39 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2195EA0B28F2E7C800299B39 /* UIViewController+Extension.swift */; };
 		21C81DA328F45447000E89DA /* AreaTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81DA228F45447000E89DA /* AreaTestViewController.swift */; };
 		21ED8C5E28EFC3E40074C9A3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 21ED8C5D28EFC3E40074C9A3 /* SnapKit */; };
@@ -90,6 +91,7 @@
 		2164307328F693F500443A1B /* CustomCheckbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCheckbox.swift; sourceTree = "<group>"; };
 		2164307928F69FA600443A1B /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		216CA5B928F56433008C09C7 /* CustomGetSizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomGetSizeView.swift; sourceTree = "<group>"; };
+		2188F2F828F7B434005BC322 /* PaddedLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
 		2195EA0B28F2E7C800299B39 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		21C81DA228F45447000E89DA /* AreaTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaTestViewController.swift; sourceTree = "<group>"; };
 		21ED8C7928EFC77B0074C9A3 /* NSObject+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 		21ED8C7628EFC6840074C9A3 /* UIComponent */ = {
 			isa = PBXGroup;
 			children = (
+				2188F2F828F7B434005BC322 /* PaddedLabel.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -674,6 +677,7 @@
 				CEFFE77A28F3C5E6007A7842 /* EstimateHistoryViewController.swift in Sources */,
 				355CB85B28F09B06001A5731 /* SampleDetailView.swift in Sources */,
 				355CB86828F29F57001A5731 /* SampleCollectionViewCell.swift in Sources */,
+				2188F2F928F7B434005BC322 /* PaddedLabel.swift in Sources */,
 				355CB87028F2F716001A5731 /* ViewModelBindableType.swift in Sources */,
 				212CFA7A28F65D30003D310A /* TermsViewController.swift in Sources */,
 				CEF76BD328EE77C0003D1F49 /* AppDelegate.swift in Sources */,

--- a/Samplero/Samplero/Global/UIComponent/PaddedLabel.swift
+++ b/Samplero/Samplero/Global/UIComponent/PaddedLabel.swift
@@ -1,0 +1,47 @@
+//
+//  PaddedLabel.swift
+//  Samplero
+//
+//  Created by Minkyeong Ko on 2022/10/13.
+//
+
+import UIKit
+
+import SnapKit
+
+class PaddedLabel: UILabel {
+
+    var topInset: CGFloat
+    var bottomInset: CGFloat
+    var leftInset: CGFloat
+    var rightInset: CGFloat
+    
+    init(topInset: CGFloat, bottomInset: CGFloat, leftInset: CGFloat, rightInset: CGFloat) {
+        self.topInset = topInset
+        self.bottomInset = bottomInset
+        self.leftInset = leftInset
+        self.rightInset = rightInset
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func drawText(in rect: CGRect) {
+        let insets = UIEdgeInsets(top: topInset, left: leftInset, bottom: bottomInset, right: rightInset)
+        super.drawText(in: rect.inset(by: insets))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(width: size.width + leftInset + rightInset,
+                      height: size.height + topInset + bottomInset)
+    }
+
+    override var bounds: CGRect {
+        didSet {
+            preferredMaxLayoutWidth = bounds.width - (leftInset + rightInset)
+        }
+    }
+}

--- a/Samplero/Samplero/Global/UIComponent/PaddedLabel.swift
+++ b/Samplero/Samplero/Global/UIComponent/PaddedLabel.swift
@@ -11,10 +11,28 @@ import SnapKit
 
 class PaddedLabel: UILabel {
 
+    
+    // MARK: - Properties
+    
     var topInset: CGFloat
     var bottomInset: CGFloat
     var leftInset: CGFloat
     var rightInset: CGFloat
+    
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(width: size.width + leftInset + rightInset,
+                      height: size.height + topInset + bottomInset)
+    }
+
+    override var bounds: CGRect {
+        didSet {
+            preferredMaxLayoutWidth = bounds.width - (leftInset + rightInset)
+        }
+    }
+    
+    
+    // MARK: - Init
     
     init(topInset: CGFloat, bottomInset: CGFloat, leftInset: CGFloat, rightInset: CGFloat) {
         self.topInset = topInset
@@ -28,20 +46,11 @@ class PaddedLabel: UILabel {
         fatalError("init(coder:) has not been implemented")
     }
     
+    
+    // MARK: - Func
+
     override func drawText(in rect: CGRect) {
         let insets = UIEdgeInsets(top: topInset, left: leftInset, bottom: bottomInset, right: rightInset)
         super.drawText(in: rect.inset(by: insets))
-    }
-
-    override var intrinsicContentSize: CGSize {
-        let size = super.intrinsicContentSize
-        return CGSize(width: size.width + leftInset + rightInset,
-                      height: size.height + topInset + bottomInset)
-    }
-
-    override var bounds: CGRect {
-        didSet {
-            preferredMaxLayoutWidth = bounds.width - (leftInset + rightInset)
-        }
     }
 }

--- a/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
+++ b/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
@@ -87,6 +87,21 @@ class TermsViewController: BaseViewController {
         return button
     }()
     
+    private let toastView: PaddedLabel = {
+        let label = PaddedLabel(topInset: 16, bottomInset: 16, leftInset: 16, rightInset: 16)
+        label.text = "장바구니 내역이 복사되었습니다. \n 카카오톡 채팅방에 붙여넣어주세요!"
+        label.backgroundColor = .orange
+        label.textAlignment = .center
+        label.numberOfLines = 2
+        label.backgroundColor = UIColor(hex: "#1E1E1E").withAlphaComponent(0.75)
+        label.textColor = .white
+        label.layer.cornerRadius = 22
+        label.clipsToBounds = true
+        label.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize)
+        return label
+    }()
+    
+    
     
     // MARK: - Life Cycle
     
@@ -139,5 +154,21 @@ class TermsViewController: BaseViewController {
     
     @objc func sendAlert() {
         makeAlert(title: "알림", message: "약관에 동의하지 않으면 샘플을 주문할 수 없어요.")
+    }
+    
+    @objc func showToastAnimation() {
+        toastView.alpha = 1.0
+            
+        self.view.addSubview(toastView)
+        toastView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalToSuperview().inset(147)
+        }
+        
+        UIView.animate(withDuration: 1.5, delay: 1.4, options: .curveEaseIn, animations: {
+            self.toastView.alpha = 0.0
+        }, completion: { _ in
+            self.toastView.removeFromSuperview()
+        })
     }
 }

--- a/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
+++ b/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
@@ -21,6 +21,7 @@ private enum Size {
     static let checkboxCornerRadius = 5.0
     static let checkboxBorderWidth = 1.0
     static let termsContentsInset = UIEdgeInsets(top: 20, left: 18, bottom: 20, right: 18)
+    static let toastViewCornerRadius = 14.0
 }
 
 class TermsViewController: BaseViewController {
@@ -88,14 +89,14 @@ class TermsViewController: BaseViewController {
     }()
     
     private let toastView: PaddedLabel = {
-        let label = PaddedLabel(topInset: 16, bottomInset: 16, leftInset: 16, rightInset: 16)
+        let label = PaddedLabel(topInset: 16, bottomInset: 16, leftInset: 40, rightInset: 40)
         label.text = "장바구니 내역이 복사되었습니다. \n 카카오톡 채팅방에 붙여넣어주세요!"
         label.backgroundColor = .orange
         label.textAlignment = .center
         label.numberOfLines = 2
         label.backgroundColor = UIColor(hex: "#1E1E1E").withAlphaComponent(0.75)
         label.textColor = .white
-        label.layer.cornerRadius = 22
+        label.layer.cornerRadius = Size.toastViewCornerRadius
         label.clipsToBounds = true
         label.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize)
         return label
@@ -154,6 +155,7 @@ class TermsViewController: BaseViewController {
     
     @objc func sendAlert() {
         makeAlert(title: "알림", message: "약관에 동의하지 않으면 샘플을 주문할 수 없어요.")
+        showToastAnimation()
     }
     
     @objc func showToastAnimation() {


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #38 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
<img width="260" alt="" src="https://user-images.githubusercontent.com/78426896/195488951-a50bf12b-f2be-41e2-bb6c-70675c954b72.png" />

- UILabel에 패딩을 넣기 위해 PaddedLabel이라는 UIComponent를 추가하였습니다. 패딩 값을 넣어 재사용하실 수 있습니다.
- TermsViewController에 Toast 메시지를 띄울 수 있는 showToastAnimation이라는 함수를 추가하였습니다.


## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 약관 동의시 버튼 활성화 기능
 - [ ] 특정 순간에 클립 보드 복사 및 Toast 띄우기
 - [ ] 버튼 누르면 카카오톡으로 이동

