### PR TITLE
[FEAT] 클립보드 복사 및 카카오 링크 연결 구현

### DIFF
--- a/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
+++ b/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
@@ -173,10 +173,9 @@ class TermsViewController: BaseViewController {
             // FIXME: - 테스트 용 string입니다. 추후 장바구니 내역으로 수정 필요
             UIPasteboard.general.string = "장바구니 내역"
             
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2) {
-                if let url = URL(string: "https://pf.kakao.com/_xalMTxj/chat") {
-                    UIApplication.shared.open(url, options: [:])
-                }
+            sleep(2)
+            if let url = URL(string: "https://pf.kakao.com/_xalMTxj/chat") {
+                UIApplication.shared.open(url, options: [:])
             }
         } else {
             makeAlert(title: "알림", message: "약관에 동의하지 않으면 샘플을 주문할 수 없어요.")

--- a/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
+++ b/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
@@ -169,6 +169,10 @@ class TermsViewController: BaseViewController {
     @objc func buttonTapped() {
         if checkboxImageView.isChecked {
 //            showToastAnimation()
+            
+            // FIXME: - 테스트 용 string입니다. 추후 장바구니 내역으로 수정 필요
+            UIPasteboard.general.string = "장바구니 내역"
+            
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2) {
                 if let url = URL(string: "https://pf.kakao.com/_xalMTxj/chat") {
                     UIApplication.shared.open(url, options: [:])

--- a/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
+++ b/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
@@ -89,6 +89,7 @@ class TermsViewController: BaseViewController {
     
     let viewModel = TermsViewModel(isChecked: false)
     
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -167,10 +168,14 @@ class TermsViewController: BaseViewController {
     
     @objc func buttonTapped() {
         if checkboxImageView.isChecked {
-            // 카카오 채널로 이동
+//            showToastAnimation()
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2) {
+                if let url = URL(string: "https://pf.kakao.com/_xalMTxj/chat") {
+                    UIApplication.shared.open(url, options: [:])
+                }
+            }
         } else {
             makeAlert(title: "알림", message: "약관에 동의하지 않으면 샘플을 주문할 수 없어요.")
         }
     }
-    
 }


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #47 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
<img width="260" alt="image" src="https://user-images.githubusercontent.com/78426896/195525098-995fc708-a550-42ab-9451-4b3d1fdcebf2.gif" />

- 약관 동의 후 카카오톡 연결 버튼을 누르면 Toast메시지를 띄우고 2초 뒤 카카오톡 채널 링크로 이동하도록 하였습니다.
- 동시에 String이 클립보드에 복사되도록 하였습니다.
- Toast 관련 코드가 다른 PR에 있어서 우선 호출하는 부분은 주석처리 해 놓았습니다.
- ❗️ 어쩔 수 없이 선행되는 PR이 있어, 꼭 #47 이 포함된  2ab3b83b8038595ca010f4ac9b0ee0605b1f6c4b 이 커밋과 444e3b4c3605d895cfa86e2315507f40ff8dfb88 이 커밋 만을 선택해서 봐 주시면 감사하겠습니다! (양이 굉장히 작습니다ㅎㅎ)

## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
- DispatchQueue에 익숙하지 않아서 잘못된 부분이 있다면 알려주세요!
- url이 명확하기 때문에 오류 처리 같은 건 안 해줘도 되겠죠..?!

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 장바구니 화면과 연결
 - [ ] 장바구니 내역을 복사

