### PR TITLE
[ADD] 예상 가격 및 면적 입력 UI 수정, 상황에 맞는 뷰 생성

### DIFF
--- a/Samplero/Samplero.xcodeproj/project.pbxproj
+++ b/Samplero/Samplero.xcodeproj/project.pbxproj
@@ -12,12 +12,13 @@
 		210CC67F28F26FD5008191A9 /* BottomSheetTransitioningDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210CC67E28F26FD5008191A9 /* BottomSheetTransitioningDelegate.swift */; };
 		210CC68128F26FEF008191A9 /* BottomSheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210CC68028F26FEF008191A9 /* BottomSheetController.swift */; };
 		210CC68328F2700C008191A9 /* GetAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210CC68228F2700C008191A9 /* GetAreaViewController.swift */; };
+		212135F928F8499E0049B28D /* PaddedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212135F828F8499E0049B28D /* PaddedButton.swift */; };
 		212CFA7A28F65D30003D310A /* TermsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212CFA7928F65D30003D310A /* TermsViewController.swift */; };
 		2164307428F693F500443A1B /* CustomCheckbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164307328F693F500443A1B /* CustomCheckbox.swift */; };
 		2164307A28F69FA600443A1B /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164307928F69FA600443A1B /* UIViewController+Alert.swift */; };
 		216CA5BA28F56433008C09C7 /* CustomGetSizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216CA5B928F56433008C09C7 /* CustomGetSizeView.swift */; };
-		2188F2FC28F7D59E005BC322 /* TermsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188F2FB28F7D59E005BC322 /* TermsViewModel.swift */; };
 		2188F2F928F7B434005BC322 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188F2F828F7B434005BC322 /* PaddedLabel.swift */; };
+		2188F2FC28F7D59E005BC322 /* TermsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2188F2FB28F7D59E005BC322 /* TermsViewModel.swift */; };
 		2195EA0C28F2E7C800299B39 /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2195EA0B28F2E7C800299B39 /* UIViewController+Extension.swift */; };
 		21C81DA328F45447000E89DA /* AreaTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C81DA228F45447000E89DA /* AreaTestViewController.swift */; };
 		21ED8C5E28EFC3E40074C9A3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 21ED8C5D28EFC3E40074C9A3 /* SnapKit */; };
@@ -88,12 +89,13 @@
 		210CC67E28F26FD5008191A9 /* BottomSheetTransitioningDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetTransitioningDelegate.swift; sourceTree = "<group>"; };
 		210CC68028F26FEF008191A9 /* BottomSheetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetController.swift; sourceTree = "<group>"; };
 		210CC68228F2700C008191A9 /* GetAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAreaViewController.swift; sourceTree = "<group>"; };
+		212135F828F8499E0049B28D /* PaddedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedButton.swift; sourceTree = "<group>"; };
 		212CFA7928F65D30003D310A /* TermsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsViewController.swift; sourceTree = "<group>"; };
 		2164307328F693F500443A1B /* CustomCheckbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCheckbox.swift; sourceTree = "<group>"; };
 		2164307928F69FA600443A1B /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
 		216CA5B928F56433008C09C7 /* CustomGetSizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomGetSizeView.swift; sourceTree = "<group>"; };
-		2188F2FB28F7D59E005BC322 /* TermsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsViewModel.swift; sourceTree = "<group>"; };
 		2188F2F828F7B434005BC322 /* PaddedLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
+		2188F2FB28F7D59E005BC322 /* TermsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsViewModel.swift; sourceTree = "<group>"; };
 		2195EA0B28F2E7C800299B39 /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		21C81DA228F45447000E89DA /* AreaTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AreaTestViewController.swift; sourceTree = "<group>"; };
 		21ED8C7928EFC77B0074C9A3 /* NSObject+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 			isa = PBXGroup;
 			children = (
 				2188F2F828F7B434005BC322 /* PaddedLabel.swift */,
+				212135F828F8499E0049B28D /* PaddedButton.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -718,6 +721,7 @@
 				CE9C460828F4595900890821 /* TakenPictureViewController.swift in Sources */,
 				210CC68128F26FEF008191A9 /* BottomSheetController.swift in Sources */,
 				210CC67D28F26FBD008191A9 /* BottomSheetPresentationController.swift in Sources */,
+				212135F928F8499E0049B28D /* PaddedButton.swift in Sources */,
 				355CB87128F2F716001A5731 /* ViewModelType.swift in Sources */,
 				2164307A28F69FA600443A1B /* UIViewController+Alert.swift in Sources */,
 				35084E4A28F0292C00621C0D /* Color+Extension.swift in Sources */,

--- a/Samplero/Samplero.xcodeproj/project.pbxproj
+++ b/Samplero/Samplero.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		210CC68128F26FEF008191A9 /* BottomSheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210CC68028F26FEF008191A9 /* BottomSheetController.swift */; };
 		210CC68328F2700C008191A9 /* GetAreaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210CC68228F2700C008191A9 /* GetAreaViewController.swift */; };
 		212135F928F8499E0049B28D /* PaddedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212135F828F8499E0049B28D /* PaddedButton.swift */; };
+		212135FB28F84CC20049B28D /* EstimatedPriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212135FA28F84CC20049B28D /* EstimatedPriceView.swift */; };
+		212135FD28F858D10049B28D /* ToBeEstimatedPriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212135FC28F858D10049B28D /* ToBeEstimatedPriceView.swift */; };
 		212CFA7A28F65D30003D310A /* TermsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212CFA7928F65D30003D310A /* TermsViewController.swift */; };
 		2164307428F693F500443A1B /* CustomCheckbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164307328F693F500443A1B /* CustomCheckbox.swift */; };
 		2164307A28F69FA600443A1B /* UIViewController+Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2164307928F69FA600443A1B /* UIViewController+Alert.swift */; };
@@ -90,6 +92,8 @@
 		210CC68028F26FEF008191A9 /* BottomSheetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetController.swift; sourceTree = "<group>"; };
 		210CC68228F2700C008191A9 /* GetAreaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAreaViewController.swift; sourceTree = "<group>"; };
 		212135F828F8499E0049B28D /* PaddedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddedButton.swift; sourceTree = "<group>"; };
+		212135FA28F84CC20049B28D /* EstimatedPriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EstimatedPriceView.swift; sourceTree = "<group>"; };
+		212135FC28F858D10049B28D /* ToBeEstimatedPriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToBeEstimatedPriceView.swift; sourceTree = "<group>"; };
 		212CFA7928F65D30003D310A /* TermsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsViewController.swift; sourceTree = "<group>"; };
 		2164307328F693F500443A1B /* CustomCheckbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCheckbox.swift; sourceTree = "<group>"; };
 		2164307928F69FA600443A1B /* UIViewController+Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Alert.swift"; sourceTree = "<group>"; };
@@ -182,6 +186,8 @@
 				210CC67C28F26FBD008191A9 /* BottomSheetPresentationController.swift */,
 				210CC67A28F26F8B008191A9 /* BottomSheetInteractiveDismissalTransition.swift */,
 				21C81DA228F45447000E89DA /* AreaTestViewController.swift */,
+				212135FA28F84CC20049B28D /* EstimatedPriceView.swift */,
+				212135FC28F858D10049B28D /* ToBeEstimatedPriceView.swift */,
 			);
 			path = Calculation;
 			sourceTree = "<group>";
@@ -711,6 +717,7 @@
 				CEFFE78C28F3D7A3007A7842 /* BaseCollectionViewCell.swift in Sources */,
 				2188F2FC28F7D59E005BC322 /* TermsViewModel.swift in Sources */,
 				35084E4C28F02A9300621C0D /* ImageLiteral.swift in Sources */,
+				212135FD28F858D10049B28D /* ToBeEstimatedPriceView.swift in Sources */,
 				21ED8C8028EFC7990074C9A3 /* BaseTableViewCell.swift in Sources */,
 				355CB85428F0843D001A5731 /* EstimateViewController.swift in Sources */,
 				355CB86D28F2EFEF001A5731 /* EstimateViewModel.swift in Sources */,
@@ -724,6 +731,7 @@
 				212135F928F8499E0049B28D /* PaddedButton.swift in Sources */,
 				355CB87128F2F716001A5731 /* ViewModelType.swift in Sources */,
 				2164307A28F69FA600443A1B /* UIViewController+Alert.swift in Sources */,
+				212135FB28F84CC20049B28D /* EstimatedPriceView.swift in Sources */,
 				35084E4A28F0292C00621C0D /* Color+Extension.swift in Sources */,
 				CEFFE77D28F3C689007A7842 /* EstimateHistoryCollectionViewCell.swift in Sources */,
 			);

--- a/Samplero/Samplero/Global/UIComponent/PaddedButton.swift
+++ b/Samplero/Samplero/Global/UIComponent/PaddedButton.swift
@@ -1,0 +1,43 @@
+//
+//  PaddedButton.swift
+//  Samplero
+//
+//  Created by Minkyeong Ko on 2022/10/13.
+//
+
+import UIKit
+
+import SnapKit
+
+class PaddedButton: UIButton {
+
+    
+    // MARK: - Properties
+    
+    var topInset: CGFloat
+    var bottomInset: CGFloat
+    var leftInset: CGFloat
+    var rightInset: CGFloat
+    
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(width: size.width + leftInset + rightInset,
+                      height: size.height + topInset + bottomInset)
+    }
+    
+    
+    // MARK: - Init
+    
+    init(topInset: CGFloat, bottomInset: CGFloat, leftInset: CGFloat, rightInset: CGFloat) {
+        self.topInset = topInset
+        self.bottomInset = bottomInset
+        self.leftInset = leftInset
+        self.rightInset = rightInset
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
+++ b/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
@@ -9,65 +9,52 @@ import UIKit
 
 import SnapKit
 
-final class AreaTestViewController: BaseViewController {
+final class AreaTestViewController: BaseViewController, ShowModalDelegate {
 
     // MARK: - Properties
-    private let priceLabel: UILabel = {
-        let label = UILabel()
-        label.text = "예상 가격"
-        label.font = .systemFont(ofSize: 16, weight: .semibold)
-        label.textColor = .white
-        label.textAlignment = .center
-        return label
-    }()
     
-    private let textButton: PaddedButton = {
-        let button = PaddedButton(topInset: 7, bottomInset: 7, leftInset: 17, rightInset: 17)
-        button.addTarget(self, action: #selector(buttonDidTap), for: .touchUpInside)
-        button.titleLabel?.font = .systemFont(ofSize: 12, weight: .bold)
-        button.tintColor = .white
-        button.setTitle("면적 입력하기", for: .normal)
-        button.backgroundColor = UIColor.white.withAlphaComponent(0.5)
-        return button
-    }()
-    
-    private let priceAndAreaStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.backgroundColor = .black
-        stackView.alpha = 0.5
-        stackView.distribution = .equalCentering
-        stackView.alignment = .center
-        return stackView
-    }()
+    private let toBeEstimatedPriceView = ToBeEstimatedPriceView()
+    private let estimatedPriceView = EstimatedPriceView(estimatedPrice: "1,200,000원", width: 1100, height: 1200, estimatedQuantity: 80, pricePerBlock: "15,000")
     
     // MARK: - Life Cycle
     
     override func viewDidLayoutSubviews() {
-        textButton.layer.cornerRadius = textButton.bounds.height/2
+        toBeEstimatedPriceView.textButton.layer.cornerRadius = toBeEstimatedPriceView.textButton.bounds.height/2
+        estimatedPriceView.textButton.layer.cornerRadius = estimatedPriceView.textButton.bounds.height/2
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        toBeEstimatedPriceView.delegate = self
+        estimatedPriceView.delegate = self
     }
     
     override func render() {
-        view.addSubview(priceAndAreaStackView)
-  
-        priceAndAreaStackView.addArrangedSubview(priceLabel)
-        priceLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(20)
+        view.addSubview(toBeEstimatedPriceView)
+        toBeEstimatedPriceView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+            make.center.equalToSuperview().inset(100)
+            make.height.equalTo(80)
         }
         
-        priceAndAreaStackView.addArrangedSubview(textButton)
-        textButton.snp.makeConstraints { make in
-            make.trailing.equalTo(view).inset(20)
-        }
-        
-        priceAndAreaStackView.snp.makeConstraints { make in
-            make.center.equalTo(view)
-            make.leading.trailing.equalTo(view)
+        view.addSubview(estimatedPriceView)
+        estimatedPriceView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+            make.center.equalToSuperview().offset(100)
             make.height.equalTo(80)
         }
     }
     
+    func buttonDidTapped() {
+        let viewController = GetAreaViewController()
+        viewController.preferredSheetSizing = .medium
+        present(viewController, animated: true)
+    }
+    
     override func configUI() {
+        toBeEstimatedPriceView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        estimatedPriceView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
     }
     
     

--- a/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
+++ b/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class AreaTestViewController: BaseViewController, ShowModalDelegate {
+final class AreaTestViewController: BaseViewController {
 
     // MARK: - Properties
     
@@ -26,8 +26,7 @@ final class AreaTestViewController: BaseViewController, ShowModalDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        toBeEstimatedPriceView.delegate = self
-        estimatedPriceView.delegate = self
+        setDelegation()
     }
     
     override func render() {
@@ -46,12 +45,6 @@ final class AreaTestViewController: BaseViewController, ShowModalDelegate {
         }
     }
     
-    func buttonDidTapped() {
-        let viewController = GetAreaViewController()
-        viewController.preferredSheetSizing = .medium
-        present(viewController, animated: true)
-    }
-    
     override func configUI() {
         toBeEstimatedPriceView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
         estimatedPriceView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
@@ -61,6 +54,19 @@ final class AreaTestViewController: BaseViewController, ShowModalDelegate {
     // MARK: - Func
     
     @objc func buttonDidTap() {
+        let viewController = GetAreaViewController()
+        viewController.preferredSheetSizing = .medium
+        present(viewController, animated: true)
+    }
+    
+    private func setDelegation() {
+        toBeEstimatedPriceView.delegate = self
+        estimatedPriceView.delegate = self
+    }
+}
+
+extension AreaTestViewController: ShowModalDelegate {
+    func buttonDidTapped() {
         let viewController = GetAreaViewController()
         viewController.preferredSheetSizing = .medium
         present(viewController, animated: true)

--- a/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
+++ b/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
@@ -21,22 +21,14 @@ final class AreaTestViewController: BaseViewController {
         return label
     }()
     
-    private let getAreaButton = UIView()
-    
-    private let textButton: UIButton = {
-        let button = UIButton(type: .system)
+    private let textButton: PaddedButton = {
+        let button = PaddedButton(topInset: 7, bottomInset: 7, leftInset: 17, rightInset: 17)
         button.addTarget(self, action: #selector(buttonDidTap), for: .touchUpInside)
-        button.titleLabel?.font = .systemFont(ofSize: 12, weight: .light)
+        button.titleLabel?.font = .systemFont(ofSize: 12, weight: .bold)
         button.tintColor = .white
-        button.setTitle("견적 계산을 위해 공간의 면적을 입력해주세요", for: .normal)
+        button.setTitle("면적 입력하기", for: .normal)
+        button.backgroundColor = UIColor.white.withAlphaComponent(0.5)
         return button
-    }()
-    
-    private let roundedRectangle: UIView = {
-        let rect = UIView()
-        rect.backgroundColor = .black
-        rect.alpha = 0.5
-        return rect
     }()
     
     private let priceAndAreaStackView: UIStackView = {
@@ -44,7 +36,7 @@ final class AreaTestViewController: BaseViewController {
         stackView.axis = .horizontal
         stackView.backgroundColor = .black
         stackView.alpha = 0.5
-        stackView.distribution = .equalSpacing
+        stackView.distribution = .equalCentering
         stackView.alignment = .center
         return stackView
     }()
@@ -52,33 +44,22 @@ final class AreaTestViewController: BaseViewController {
     // MARK: - Life Cycle
     
     override func viewDidLayoutSubviews() {
-        roundedRectangle.layer.cornerRadius = roundedRectangle.bounds.height/2
-        roundedRectangle.layer.borderWidth = 1
-        roundedRectangle.layer.borderColor = UIColor.white.cgColor
+        textButton.layer.cornerRadius = textButton.bounds.height/2
     }
     
     override func render() {
         view.addSubview(priceAndAreaStackView)
-        getAreaButton.addSubview(roundedRectangle)
-        getAreaButton.addSubview(textButton)
-        
-        textButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(23)
-            make.center.equalToSuperview()
-        }
-        roundedRectangle.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.center.equalToSuperview()
-            make.width.equalTo(textButton).multipliedBy(1.1)
-            make.height.equalTo(40)
-        }
-        
+  
         priceAndAreaStackView.addArrangedSubview(priceLabel)
         priceLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(23)
+            make.leading.equalToSuperview().offset(20)
         }
         
-        priceAndAreaStackView.addArrangedSubview(getAreaButton)
+        priceAndAreaStackView.addArrangedSubview(textButton)
+        textButton.snp.makeConstraints { make in
+            make.trailing.equalTo(view).inset(20)
+        }
+        
         priceAndAreaStackView.snp.makeConstraints { make in
             make.center.equalTo(view)
             make.leading.trailing.equalTo(view)

--- a/Samplero/Samplero/Screen/Calculation/EstimatedPriceView.swift
+++ b/Samplero/Samplero/Screen/Calculation/EstimatedPriceView.swift
@@ -1,0 +1,122 @@
+//
+//  EstimatedPriceView.swift
+//  Samplero
+//
+//  Created by Minkyeong Ko on 2022/10/13.
+//
+
+import UIKit
+
+class EstimatedPriceView: UIView {
+    
+    
+    // MARK: - Properties
+    
+    var delegate: ShowModalDelegate?
+    
+    private let priceLabel: UILabel = {
+        let label = UILabel()
+        label.text = "예상 가격"
+        label.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize)
+        label.textColor = .white
+        label.textAlignment = .left
+        return label
+    }()
+    
+    private let showPriceLabel: UILabel = {
+        let label = UILabel()
+        label.font = .boldSystemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize)
+        label.textColor = .white
+        label.textAlignment = .left
+        return label
+    }()
+    
+    private let estimatedPriceStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        return stackView
+    }()
+    
+    let textButton: PaddedButton = {
+        let button = PaddedButton(topInset: 4, bottomInset: 4, leftInset: 8, rightInset: 8)
+        button.addTarget(self, action: #selector(tapButton(sender:)), for: .touchUpInside)
+        button.titleLabel?.font = .systemFont(ofSize: 12, weight: .bold)
+        button.tintColor = .white
+        button.setTitle("변경", for: .normal)
+        button.backgroundColor = UIColor.white.withAlphaComponent(0.5)
+        return button
+    }()
+    
+    private let sizeAndQuantityLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize)
+        label.textColor = .white
+        return label
+    }()
+    
+    private let pricePerBlockLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .caption1).pointSize)
+        label.textColor = .white
+        return label
+    }()
+    
+    private let showQuantityAndPriceStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .trailing
+        return stackView
+    }()
+    
+    
+    // MARK: - Init
+    
+    init(estimatedPrice: String, width: Int, height: Int, estimatedQuantity: Int, pricePerBlock: String) {
+        super.init(frame: .zero)
+        self.showPriceLabel.text = estimatedPrice
+        self.sizeAndQuantityLabel.text = "\(width)x\(height)(cm), \(estimatedQuantity)장"
+        self.pricePerBlockLabel.text = "장당 \(pricePerBlock)원"
+        render()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    
+    // MARK: - Func
+    
+    private func render() {
+        self.addSubview(estimatedPriceStackView)
+        estimatedPriceStackView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(20)
+        }
+        estimatedPriceStackView.addArrangedSubview(priceLabel)
+        estimatedPriceStackView.addArrangedSubview(showPriceLabel)
+        
+        self.addSubview(textButton)
+        textButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalTo(self.snp.trailing).inset(20)
+        }
+        
+        self.addSubview(showQuantityAndPriceStackView)
+        showQuantityAndPriceStackView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalTo(textButton.snp.leading).offset(-7)
+        }
+        showQuantityAndPriceStackView.addArrangedSubview(sizeAndQuantityLabel)
+        showQuantityAndPriceStackView.addArrangedSubview(pricePerBlockLabel)
+
+    }
+
+    @objc func tapButton(sender: UIButton) {
+        delegate?.buttonDidTapped()
+    }
+}
+
+protocol ShowModalDelegate {
+    func buttonDidTapped()
+}

--- a/Samplero/Samplero/Screen/Calculation/ToBeEstimatedPriceView.swift
+++ b/Samplero/Samplero/Screen/Calculation/ToBeEstimatedPriceView.swift
@@ -1,0 +1,68 @@
+//
+//  ToBeEstimatedPriceView.swift
+//  Samplero
+//
+//  Created by Minkyeong Ko on 2022/10/13.
+//
+
+import UIKit
+
+class ToBeEstimatedPriceView: UIView {
+    
+    
+    // MARK: - Properties
+    
+    var delegate: ShowModalDelegate?
+    
+    private let priceLabel: UILabel = {
+        let label = UILabel()
+        label.text = "예상 가격"
+        label.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize)
+        label.textColor = .white
+        label.textAlignment = .left
+        return label
+    }()
+    
+    let textButton: PaddedButton = {
+        let button = PaddedButton(topInset: 7, bottomInset: 7, leftInset: 17, rightInset: 17)
+        button.addTarget(self, action: #selector(tapButton(sender:)), for: .touchUpInside)
+        button.titleLabel?.font = .systemFont(ofSize: 12, weight: .bold)
+        button.tintColor = .white
+        button.setTitle("면적 입력하기", for: .normal)
+        button.backgroundColor = UIColor.white.withAlphaComponent(0.5)
+        return button
+    }()
+    
+    
+    // MARK: - Init
+    
+    init() {
+        super.init(frame: .zero)
+        render()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    
+    // MARK: - Func
+
+    private func render() {
+        self.addSubview(priceLabel)
+        priceLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(20)
+        }
+        self.addSubview(textButton)
+        textButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(20)
+        }
+    }
+
+    @objc func tapButton(sender: UIButton) {
+        delegate?.buttonDidTapped()
+    }
+    
+}


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #52 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
<img width="260" alt="image" src="https://user-images.githubusercontent.com/78426896/195632410-7a1cf0f6-d345-4d47-a35c-05fefece17e2.png" />

- UI 내부를 바꾸기 보다 상황에 맞는 뷰를 대체해 주는 게 더 나을 것 같다고 판단하였습니다. 
- 따라서 면적을 입력하기 전에 사용할 `ToBeEstimatedPriceView`와 면적을 입력하고 난 뒤 사용할 `EstimatedPriceView`를 만들었습니다.
- `EstimatedPriceView`는 생성될 때 예상 가격, 사이즈 정보, 필요한 수량 정보, 장당 가격 정보를 받아서 화면에 표시합니다.
- `AreaTestViewController`는 두 뷰를 확인하는 역할을 하고, 추후 `SampleDetailView`로 연결되면 사라질 예정입니다.

## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
- 예상 면적을 입력하는 `GetAreaViewController`의 너비와 높이 값들을 `SampleDetailView`가 가져와서 계산 후 `EstimatedPriceView`를 생성하는 방식으로 가야할 것 같은데.. 괜찮을지 모르겠습니다

## ⁴/₄ 다음으로 진행될 작업
 - [ ] RxSwift 사용해서 `AreaViewController`(테스트 컨트롤러)와 `GetAreaViewController` 데이터 연결하기

