### PR TITLE
[FIX] 견적내역으로 이동하는 버튼의 이미지 설정이 되지 않는 에러 해결

### DIFF
--- a/Samplero/Samplero.xcodeproj/project.pbxproj
+++ b/Samplero/Samplero.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		CE1052E128F279DB00503ECF /* CameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1052E028F279DB00503ECF /* CameraViewController.swift */; };
 		CE13B6C728F1600B00216EB2 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = CE13B6C628F1600B00216EB2 /* .swiftlint.yml */; };
 		CE567ACD28F8F6D000AEF5E0 /* LocalFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE567ACC28F8F6D000AEF5E0 /* LocalFileManager.swift */; };
+		CE567AD328F9038700AEF5E0 /* CameraViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE567AD228F9038700AEF5E0 /* CameraViewModel.swift */; };
 		CE6379E528F59782003ED6FA /* DBHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6379E428F59782003ED6FA /* DBHelper.swift */; };
 		CE6379E828F6B19C003ED6FA /* CameraHelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6379E728F6B19C003ED6FA /* CameraHelpView.swift */; };
 		CE9C460828F4595900890821 /* TakenPictureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9C460728F4595900890821 /* TakenPictureViewController.swift */; };
@@ -123,6 +124,7 @@
 		CE1052E028F279DB00503ECF /* CameraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewController.swift; sourceTree = "<group>"; };
 		CE13B6C628F1600B00216EB2 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		CE567ACC28F8F6D000AEF5E0 /* LocalFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalFileManager.swift; sourceTree = "<group>"; };
+		CE567AD228F9038700AEF5E0 /* CameraViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewModel.swift; sourceTree = "<group>"; };
 		CE6379E428F59782003ED6FA /* DBHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBHelper.swift; sourceTree = "<group>"; };
 		CE6379E728F6B19C003ED6FA /* CameraHelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraHelpView.swift; sourceTree = "<group>"; };
 		CE9C460728F4595900890821 /* TakenPictureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakenPictureViewController.swift; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 		CE1052DD28F279A900503ECF /* Camera */ = {
 			isa = PBXGroup;
 			children = (
+				CE567AD128F9037D00AEF5E0 /* ViewModel */,
 				CE6379E628F6B16A003ED6FA /* View */,
 				CE1052E028F279DB00503ECF /* CameraViewController.swift */,
 			);
@@ -461,6 +464,14 @@
 				CE567ACC28F8F6D000AEF5E0 /* LocalFileManager.swift */,
 			);
 			path = Utility;
+			sourceTree = "<group>";
+		};
+		CE567AD128F9037D00AEF5E0 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				CE567AD228F9038700AEF5E0 /* CameraViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		CE6379E628F6B16A003ED6FA /* View */ = {
@@ -780,6 +791,7 @@
 				210CC67D28F26FBD008191A9 /* BottomSheetPresentationController.swift in Sources */,
 				355CB87128F2F716001A5731 /* ViewModelType.swift in Sources */,
 				2164307A28F69FA600443A1B /* UIViewController+Alert.swift in Sources */,
+				CE567AD328F9038700AEF5E0 /* CameraViewModel.swift in Sources */,
 				35084E4A28F0292C00621C0D /* Color+Extension.swift in Sources */,
 				CEFFE77D28F3C689007A7842 /* EstimateHistoryCollectionViewCell.swift in Sources */,
 			);

--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -24,7 +24,7 @@ class CameraViewController: BaseViewController {
     let previewLayer = AVCaptureVideoPreviewLayer()
     
     // Rx
-    let viewModel = EstimateHistoryViewModel()
+    let viewModel = CameraViewModel()
     var disposeBag = DisposeBag()
     
     // Shutter Button
@@ -193,9 +193,8 @@ class CameraViewController: BaseViewController {
     }
     
     func bind() {
-        viewModel.estimateHistorySubject
+        viewModel.estimateHistoryObservable
             .subscribe(onNext: { [weak self] history in
-                self?.photoHistoryButton.setImage(UIImage(named: "sample_photo_\(history.last?.imageId ?? 0)"), for: .normal)
             })
             .disposed(by: disposeBag)
     }

--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -23,6 +23,8 @@ class CameraViewController: BaseViewController {
     // Video Preview
     let previewLayer = AVCaptureVideoPreviewLayer()
     
+    let fileManager = LocalFileManager.instance
+    
     // Rx
     let viewModel = CameraViewModel()
     var disposeBag = DisposeBag()
@@ -195,6 +197,16 @@ class CameraViewController: BaseViewController {
     func bind() {
         viewModel.estimateHistoryObservable
             .subscribe(onNext: { [weak self] history in
+                let savingfolderName: String = "estimate-photo"
+                let floorSegmentedImageName: String = "floor-segmented-photo"
+                let imageName = floorSegmentedImageName + "-\(history.last?.imageId ?? 0)"
+                let image = self?.fileManager.getImage(imageName: imageName, folderName: savingfolderName)
+                
+                if image == nil {
+                    self?.photoHistoryButton.backgroundColor = .white
+                } else {
+                    self?.photoHistoryButton.setImage(image, for: .normal)
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/Samplero/Samplero/Screen/Camera/ViewModel/CameraViewModel.swift
+++ b/Samplero/Samplero/Screen/Camera/ViewModel/CameraViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  CameraViewModel.swift
+//  Samplero
+//
+//  Created by JiwKang on 2022/10/14.
+//
+
+import Foundation
+
+import RxSwift
+
+class CameraViewModel {
+    // MARK: - Properties
+    
+    let db = DBHelper.shared
+    
+    var disposeBag = DisposeBag()
+    
+    let estimateHistoryObservable: Observable<[EstimateHistory]>
+    
+    init () {
+        var estimateHistories: [EstimateHistory] = []
+        estimateHistories = db.getEstimateHistories()
+        
+        estimateHistoryObservable = Observable.of(estimateHistories)
+    }
+}


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #61 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
* CameraViewController의 photoHistoryButton의 image가 설정되지 않는 상황을 수정하기 위해 CameraViewModel을 추가하였습니다.
* 이미지를 db에서 가져오고 만약 db에도 사진이 없다면 흰 이미지로 대체하도록 설정하였습니다. 이때 DB에 저장되는 index는 1부터 시작하기 때문에 이미지가 없다면 0번째 index로 접근하게 하고 index가 0인 이미지가 없다면 fileManager에서 nil을 반환하도록 설정하여 흰 이미지로 대체하는 코드를 작성하였습니다.

__스크린샷__
<img width="260" alt="image" src="https://user-images.githubusercontent.com/56468120/195751056-91962498-7667-4c28-a159-afe536b5f7a3.PNG" />
<img width="260" alt="image" src="https://user-images.githubusercontent.com/56468120/195751023-3f3dc8cc-748b-48bb-b85a-80a85ddb7552.PNG" />

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 장바구니 관련 DB 작업
