### PR TITLE
[CHORE] 견적내역뷰 UI 변경

### DIFF
--- a/Samplero/Samplero/Model/MockData.swift
+++ b/Samplero/Samplero/Model/MockData.swift
@@ -17,7 +17,7 @@ struct MockData {
                imageName: "WhiteMarble",
                matPrice: 12_000,
                samplePrice: 5_000,
-               material: "TPU",
+               material: "프리미엄 TPU 필름, PU폼",
                thickness: 4,
                size: CGSize(width: 120, height: 120),
                maker: "봄봄매트"),

--- a/Samplero/Samplero/Screen/Estimate/EstimateViewController.swift
+++ b/Samplero/Samplero/Screen/Estimate/EstimateViewController.swift
@@ -166,7 +166,6 @@ final class EstimateViewController: BaseViewController, ViewModelBindableType {
 
     func configure(with sample: Sample) {
         sampleDetailView.configure(with: sample)
-   //     samplePriceValueLabel.text = "\(sample.samplePrice.description)원"
     }
 }
 

--- a/Samplero/Samplero/Screen/Estimate/EstimateViewController.swift
+++ b/Samplero/Samplero/Screen/Estimate/EstimateViewController.swift
@@ -16,12 +16,13 @@ private enum Size {
     static let defaultOffset = 20.0
     static let samplePriceTopOffset = 28.0
     static let samplePriceValueLeadingOffset = 23.0
-    static let sampleAddButtonWidth = 100.0
-    static let sampleAddButtonHeight = 39.0
+    static let sampleAddButtonHeight = 50.0
     static let sampleAddButtonTopOffset = 17.0
     static let sampleAddButtonCornerRadius = 14.0
+    static let sampleAddButtonBottomOffset = 14.0
     static let cellItemSize = 40.0
     static let sampleCollectionBottomOffset = 14.0
+
 }
 
 final class EstimateViewController: BaseViewController, ViewModelBindableType {
@@ -41,38 +42,14 @@ final class EstimateViewController: BaseViewController, ViewModelBindableType {
 
     private let sampleDetailView = SampleDetailView()
 
-    private let bottomView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .systemGray6
-        return view
-    }()
-
-    // subView of bottomView
-    private let samplePriceLabel: UILabel = {
-        let label = UILabel()
-        label.textAlignment =  .natural
-        label.font = .systemFont(ofSize: 14)
-        label.text = "샘플가격"
-        label.textColor = .systemGray2
-        return label
-    }()
-
-    // subView of bottomView
-    private let samplePriceValueLabel: UILabel = {
-        let label = UILabel()
-        label.textAlignment =  .natural
-        label.font = .systemFont(ofSize: 14, weight: .bold)
-        label.textColor = .black
-        return label
-    }()
 
     // subView of bottomView
     private let sampleAddButton: UIButton = {
         let button = UIButton()
         button.setTitle("샘플담기", for: .normal)
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        button.titleLabel?.font = .boldBody
         button.setTitleColor(.white, for: .normal)
-        button.backgroundColor = .systemBlue
+        button.backgroundColor = .accent
         button.layer.cornerRadius = Size.sampleAddButtonCornerRadius
         return button
     }()
@@ -130,34 +107,15 @@ final class EstimateViewController: BaseViewController, ViewModelBindableType {
         sampleDetailView.snp.makeConstraints { make in
             make.top.equalTo(roomImageView.snp.bottom)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(Size.deviceHeight * 0.2)
+            make.height.equalTo(Size.deviceHeight * 0.18)
         }
 
-        view.addSubview(bottomView)
-        bottomView.snp.makeConstraints { make in
-            make.top.equalTo(sampleDetailView.snp.bottom)
-            make.leading.trailing.bottom.equalToSuperview()
-        }
-
-        bottomView.addSubview(samplePriceLabel)
-        samplePriceLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(Size.samplePriceTopOffset)
-            make.leading.equalToSuperview().offset(Size.defaultOffset)
-        }
-        
-        bottomView.addSubview(samplePriceValueLabel)
-        samplePriceValueLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(Size.samplePriceTopOffset)
-            make.leading.equalTo(samplePriceLabel.snp.trailing).offset(Size.samplePriceValueLeadingOffset)
-        }
-
-        bottomView.addSubview(sampleAddButton)
+        view.addSubview(sampleAddButton)
         sampleAddButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(Size.sampleAddButtonTopOffset)
-            make.trailing.equalToSuperview().inset(Size.defaultOffset)
-            make.width.equalTo(Size.sampleAddButtonWidth)
+            make.top.equalTo(sampleDetailView.snp.bottom)
+            make.leading.trailing.equalToSuperview().inset(Size.defaultOffset)
             make.height.equalTo(Size.sampleAddButtonHeight)
-
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(Size.sampleAddButtonBottomOffset)
         }
 
     }
@@ -208,7 +166,7 @@ final class EstimateViewController: BaseViewController, ViewModelBindableType {
 
     func configure(with sample: Sample) {
         sampleDetailView.configure(with: sample)
-        samplePriceValueLabel.text = "\(sample.samplePrice.description)원"
+   //     samplePriceValueLabel.text = "\(sample.samplePrice.description)원"
     }
 }
 

--- a/Samplero/Samplero/Screen/Estimate/View/EstimateCommonStackView.swift
+++ b/Samplero/Samplero/Screen/Estimate/View/EstimateCommonStackView.swift
@@ -7,7 +7,9 @@
 
 import UIKit
 
-
+private enum Size {
+    static let valueLabelWidth = 101
+}
 final class EstimateCommonStackView: UIStackView {
 
 
@@ -17,15 +19,15 @@ final class EstimateCommonStackView: UIStackView {
     private let nameLabel: UILabel = {
         let label = UILabel()
         label.textAlignment =  .left
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .systemGray2
+        label.font = .regularSubheadline
+        label.textColor = .secondaryGray
         return label
     }()
 
     private let valueLabel: UILabel = {
         let label = UILabel()
         label.textAlignment =  .left
-        label.font = .systemFont(ofSize: 14)
+        label.font = .regularSubheadline
         label.textColor = .black
         return label
     }()
@@ -39,7 +41,8 @@ final class EstimateCommonStackView: UIStackView {
         nameLabel.text = detailName
         self.axis = .horizontal
         self.alignment = .leading
-        self.distribution = .fillEqually
+        self.distribution = .fill
+        self.spacing = 24
         render()
     }
 
@@ -53,12 +56,9 @@ final class EstimateCommonStackView: UIStackView {
 
     private func render() {
         self.addArrangedSubview(nameLabel)
-        nameLabel.snp.makeConstraints { make in
-            make.width.equalToSuperview().multipliedBy(0.5)
-        }
         self.addArrangedSubview(valueLabel)
         valueLabel.snp.makeConstraints { make in
-            make.width.equalToSuperview().multipliedBy(0.5)
+            make.width.equalTo(Size.valueLabelWidth)
         }
     }
 
@@ -66,4 +66,11 @@ final class EstimateCommonStackView: UIStackView {
         valueLabel.text = value
     }
 
+    func setValueLabelWidth(_ width: CGFloat) {
+        valueLabel.snp.updateConstraints { make in
+            make.width.equalTo(width)
+        }
+    }
+
 }
+

--- a/Samplero/Samplero/Screen/Estimate/View/SampleDetailView.swift
+++ b/Samplero/Samplero/Screen/Estimate/View/SampleDetailView.swift
@@ -10,10 +10,13 @@ import UIKit
 private enum Size {
     static let defaultOffset = 20.0
     static let horizontalLineHeight = 1
-    static let horizontalLineTopOffset = 17
-    static let vStackViewTopOffset = 10
+    static let horizontalLineTopOffset = 12
+    static let vStackViewTopOffset = 12
     static let vStackViewSpacing = 8.0
-    static let nameStackViewTopOffset = 27
+    static let nameStackViewTopOffset = 2
+    static let materialStackViewWidth = 276.0
+    static let makerLabelTopOffset = 12.0
+    static let samplePriceStackViewSpacing = 24.0
 }
 
 
@@ -22,37 +25,61 @@ final class SampleDetailView: UIView {
 
     // MARK: - Properties
 
-
+    private let makerLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment =  .left
+        label.font = .regularCaption1
+        label.textColor = .secondaryGray
+        return label
+    }()
     private let sampleNameLabel: UILabel = {
         let label = UILabel()
         label.textAlignment =  .left
-        label.font = .systemFont(ofSize: 16, weight: .bold)
+        label.font = .boldBody
         label.textColor = .black
         return label
     }()
 
-    private let matPriceLabel: UILabel = {
+    private let samplePriceLabel: UILabel = {
         let label = UILabel()
-        label.textAlignment =  .right
-        label.font = .systemFont(ofSize: 16, weight: .bold)
-        label.textColor = .black
+        label.textAlignment =  .left
+        label.font = .regularSubheadline
+        label.text = "샘플가격"
+        label.textColor = .secondaryGray
         return label
+    }()
+
+    private let samplePriceValueLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment =  .left
+        label.font = .boldSubheadline
+        label.textColor = .primaryBlack
+        return label
+    }()
+
+    private let samplePriceStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        stackView.spacing = Size.samplePriceStackViewSpacing
+        return stackView
     }()
 
     private let nameStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.alignment = .center
-        stackView.distribution = .fillEqually
+        stackView.distribution = .fill
         return stackView
     }()
 
     private let horizontalLine: UIView = {
         let view = UIView()
-        view.backgroundColor = .black
+        view.backgroundColor = .primaryBlack
+        view.layer.opacity = 0.5
         return view
     }()
-
 
     private let materialStackView = EstimateCommonStackView(detailName: "소재")
 
@@ -60,14 +87,12 @@ final class SampleDetailView: UIView {
 
     private let sizeStackView = EstimateCommonStackView(detailName: "크기")
 
-    private let makerStackView = EstimateCommonStackView(detailName: "제조사")
-
     private let firstHorizontalView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.alignment = .leading
-        stackView.distribution = .fillEqually
-        stackView.spacing = Size.defaultOffset
+        stackView.distribution = .fill
+      //  stackView.spacing = Size.defaultOffset
         return stackView
     }()
 
@@ -75,8 +100,8 @@ final class SampleDetailView: UIView {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.alignment = .leading
-        stackView.distribution = .fillEqually
-        stackView.spacing = Size.defaultOffset
+        stackView.distribution = .fill
+       // stackView.spacing = Size.defaultOffset
         return stackView
     }()
 
@@ -108,11 +133,20 @@ final class SampleDetailView: UIView {
 
     private func render() {
         nameStackView.addArrangedSubview(sampleNameLabel)
-        nameStackView.addArrangedSubview(matPriceLabel)
+        nameStackView.addArrangedSubview(UIView())
+        nameStackView.addArrangedSubview(samplePriceStackView)
+        samplePriceStackView.addArrangedSubview(samplePriceLabel)
+        samplePriceStackView.addArrangedSubview(samplePriceValueLabel)
 
+      //  samplePriceStackView.setValueLabelWidth(100)
+        self.addSubview(makerLabel)
+        makerLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(Size.makerLabelTopOffset)
+            make.leading.trailing.equalToSuperview().inset(Size.defaultOffset)
+        }
         self.addSubview(nameStackView)
         nameStackView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(Size.nameStackViewTopOffset)
+            make.top.equalTo(makerLabel.snp.bottom).offset(Size.nameStackViewTopOffset)
             make.leading.trailing.equalToSuperview().inset(Size.defaultOffset)
         }
 
@@ -133,13 +167,17 @@ final class SampleDetailView: UIView {
         verticalStackView.addArrangedSubview(secondHorizontalView)
 
         firstHorizontalView.addArrangedSubview(materialStackView)
-        firstHorizontalView.addArrangedSubview(thicknessStackView)
+        materialStackView.setValueLabelWidth(Size.materialStackViewWidth)
+        firstHorizontalView.addArrangedSubview(UIView())
+
+       // firstHorizontalView.addArrangedSubview(thicknessStackView)
         firstHorizontalView.snp.makeConstraints { make in
             make.width.equalToSuperview()
         }
         
         secondHorizontalView.addArrangedSubview(sizeStackView)
-        secondHorizontalView.addArrangedSubview(makerStackView)
+        secondHorizontalView.addArrangedSubview(thicknessStackView)
+        secondHorizontalView.addArrangedSubview(UIView())
         secondHorizontalView.snp.makeConstraints { make in
             make.width.equalToSuperview()
         }
@@ -147,12 +185,13 @@ final class SampleDetailView: UIView {
     }
 
      func configure(with sample: Sample) {
-        sampleNameLabel.text = sample.matName
-        matPriceLabel.text = "장당 \(sample.matPrice)원"
-        materialStackView.setValueLabel(with: sample.material)
+         sampleNameLabel.text = sample.matName
+     //    matPriceLabel.text = "장당 \(sample.matPrice)원"
+         materialStackView.setValueLabel(with: sample.material)
          thicknessStackView.setValueLabel(with: "\(sample.thickness.description)cm")
          sizeStackView.setValueLabel(with: sample.size.toString)
-        makerStackView.setValueLabel(with: sample.maker)
+         makerLabel.text = sample.maker
+         samplePriceValueLabel.text = (sample.samplePrice == .zero ? "무료" : "\(sample.samplePrice.description)원")
     }
 
 

--- a/Samplero/Samplero/Screen/Estimate/View/SampleDetailView.swift
+++ b/Samplero/Samplero/Screen/Estimate/View/SampleDetailView.swift
@@ -92,7 +92,6 @@ final class SampleDetailView: UIView {
         stackView.axis = .horizontal
         stackView.alignment = .leading
         stackView.distribution = .fill
-      //  stackView.spacing = Size.defaultOffset
         return stackView
     }()
 
@@ -101,7 +100,6 @@ final class SampleDetailView: UIView {
         stackView.axis = .horizontal
         stackView.alignment = .leading
         stackView.distribution = .fill
-       // stackView.spacing = Size.defaultOffset
         return stackView
     }()
 
@@ -138,7 +136,6 @@ final class SampleDetailView: UIView {
         samplePriceStackView.addArrangedSubview(samplePriceLabel)
         samplePriceStackView.addArrangedSubview(samplePriceValueLabel)
 
-      //  samplePriceStackView.setValueLabelWidth(100)
         self.addSubview(makerLabel)
         makerLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(Size.makerLabelTopOffset)
@@ -186,7 +183,6 @@ final class SampleDetailView: UIView {
 
      func configure(with sample: Sample) {
          sampleNameLabel.text = sample.matName
-     //    matPriceLabel.text = "장당 \(sample.matPrice)원"
          materialStackView.setValueLabel(with: sample.material)
          thicknessStackView.setValueLabel(with: "\(sample.thickness.description)cm")
          sizeStackView.setValueLabel(with: sample.size.toString)


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- #56 
## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 견적내역뷰 리디자인된UI로 변경했습니다.
<img width="193" alt="image" src="https://user-images.githubusercontent.com/69894461/195757234-84cfc0f4-ea9f-4f10-b22d-76a203db9589.png">

## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 견적내역뷰 연결작업

