### PR TITLE
[FEAT] 면적 입력하면 가격 및 수량 계산

### DIFF
--- a/Samplero/Samplero/Global/Resource/Base.lproj/Main.storyboard
+++ b/Samplero/Samplero/Global/Resource/Base.lproj/Main.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Terms View Controller-->
+        <!--Area Test View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="TermsViewController" customModule="Samplero" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="AreaTestViewController" customModule="Samplero" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
+++ b/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
@@ -38,7 +38,6 @@ final class AreaTestViewController: BaseViewController {
             make.center.equalToSuperview()
             make.height.equalTo(80)
         }
-        toBeEstimatedPriceView.alpha = 1
 
         view.addSubview(estimatedPriceView)
         estimatedPriceView.snp.makeConstraints { make in
@@ -46,12 +45,13 @@ final class AreaTestViewController: BaseViewController {
             make.center.equalToSuperview()
             make.height.equalTo(80)
         }
-        estimatedPriceView.alpha = 0
     }
     
     override func configUI() {
         toBeEstimatedPriceView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        toBeEstimatedPriceView.alpha = 1
         estimatedPriceView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        estimatedPriceView.alpha = 0
     }
     
     

--- a/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
+++ b/Samplero/Samplero/Screen/Calculation/AreaTestViewController.swift
@@ -14,7 +14,9 @@ final class AreaTestViewController: BaseViewController {
     // MARK: - Properties
     
     private let toBeEstimatedPriceView = ToBeEstimatedPriceView()
-    private let estimatedPriceView = EstimatedPriceView(estimatedPrice: "1,200,000원", width: 1100, height: 1200, estimatedQuantity: 80, pricePerBlock: "15,000")
+    private let estimatedPriceView = EstimatedPriceView(estimatedPrice: 1200000, width: 1100, height: 1200, estimatedQuantity: 80, pricePerBlock: 15000)
+    
+    let getAreaViewController = GetAreaViewController()
     
     // MARK: - Life Cycle
     
@@ -33,16 +35,18 @@ final class AreaTestViewController: BaseViewController {
         view.addSubview(toBeEstimatedPriceView)
         toBeEstimatedPriceView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.center.equalToSuperview().inset(100)
+            make.center.equalToSuperview()
             make.height.equalTo(80)
         }
-        
+        toBeEstimatedPriceView.alpha = 1
+
         view.addSubview(estimatedPriceView)
         estimatedPriceView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.center.equalToSuperview().offset(100)
+            make.center.equalToSuperview()
             make.height.equalTo(80)
         }
+        estimatedPriceView.alpha = 0
     }
     
     override func configUI() {
@@ -53,22 +57,42 @@ final class AreaTestViewController: BaseViewController {
     
     // MARK: - Func
     
-    @objc func buttonDidTap() {
-        let viewController = GetAreaViewController()
-        viewController.preferredSheetSizing = .medium
-        present(viewController, animated: true)
-    }
-    
     private func setDelegation() {
         toBeEstimatedPriceView.delegate = self
         estimatedPriceView.delegate = self
+        getAreaViewController.delegate = self
+    }
+    
+    // TODO: - 샘플 정보에서 가져올 것: 장 당 가격, 샘플 크기
+    let exampleSamplePrice = 15000
+    let exampleSampleArea = 14400
+    
+    private func calculatePrice(width: Int, height: Int) -> [Int] {
+        let estimatedQuantity = width*height / exampleSampleArea
+        let estimatedPrice = exampleSamplePrice * estimatedQuantity
+        // FIXME: - 배열 말고 다른 방식 사용하기
+        return [estimatedQuantity, estimatedPrice]
     }
 }
 
 extension AreaTestViewController: ShowModalDelegate {
     func buttonDidTapped() {
-        let viewController = GetAreaViewController()
-        viewController.preferredSheetSizing = .medium
-        present(viewController, animated: true)
+        getAreaViewController.preferredSheetSizing = .medium
+        present(getAreaViewController, animated: true)
+    }
+}
+
+extension AreaTestViewController: SaveSizeDelegate {
+    func saveButtonTapped(widthString: String, heightString: String) {
+        // FIXME: - 더 안정적으로 수정
+        if widthString == "" || heightString == "" {
+            toBeEstimatedPriceView.alpha = 1
+            estimatedPriceView.alpha = 0
+        } else {
+            let quantityAndPrice = calculatePrice(width: Int(widthString) ?? 0, height: Int(heightString) ?? 0)
+            estimatedPriceView.changeEstimation(estimatedPrice: quantityAndPrice[1], width: Int(widthString) ?? 0, height: Int(heightString) ?? 0, estimatedQuantity: quantityAndPrice[0], pricePerBlock: exampleSamplePrice)
+            toBeEstimatedPriceView.alpha = 0
+            estimatedPriceView.alpha = 1
+        }
     }
 }

--- a/Samplero/Samplero/Screen/Calculation/CustomGetSizeView.swift
+++ b/Samplero/Samplero/Screen/Calculation/CustomGetSizeView.swift
@@ -11,7 +11,7 @@ class CustomGetSizeView: UIView {
     
     // MARK: - Properties
     
-    private let textField: UITextField = {
+    let textField: UITextField = {
         let textfield = UITextField()
         textfield.placeholder = "0"
         textfield.keyboardType = .numberPad

--- a/Samplero/Samplero/Screen/Calculation/EstimatedPriceView.swift
+++ b/Samplero/Samplero/Screen/Calculation/EstimatedPriceView.swift
@@ -72,11 +72,9 @@ class EstimatedPriceView: UIView {
     
     // MARK: - Init
     
-    init(estimatedPrice: String, width: Int, height: Int, estimatedQuantity: Int, pricePerBlock: String) {
+    init(estimatedPrice: Int, width: Int, height: Int, estimatedQuantity: Int, pricePerBlock: Int) {
         super.init(frame: .zero)
-        self.showPriceLabel.text = estimatedPrice
-        self.sizeAndQuantityLabel.text = "\(width)x\(height)(cm), \(estimatedQuantity)장"
-        self.pricePerBlockLabel.text = "장당 \(pricePerBlock)원"
+        changeEstimation(estimatedPrice: estimatedPrice, width: width, height: height, estimatedQuantity: estimatedQuantity, pricePerBlock: pricePerBlock)
         render()
     }
     
@@ -114,6 +112,19 @@ class EstimatedPriceView: UIView {
 
     @objc func tapButton(sender: UIButton) {
         delegate?.buttonDidTapped()
+    }
+    
+    func changeEstimation(estimatedPrice: Int, width: Int, height: Int, estimatedQuantity: Int, pricePerBlock: Int) {
+        self.showPriceLabel.text = numberFormatter(number: estimatedPrice)
+        self.sizeAndQuantityLabel.text = "\(width)x\(height)(cm), \(estimatedQuantity)장"
+        self.pricePerBlockLabel.text = "장당 \(numberFormatter(number: pricePerBlock))원"
+    }
+    
+    func numberFormatter(number: Int) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        
+        return numberFormatter.string(from: NSNumber(value: number))!
     }
 }
 

--- a/Samplero/Samplero/Screen/Calculation/GetAreaViewController.swift
+++ b/Samplero/Samplero/Screen/Calculation/GetAreaViewController.swift
@@ -10,6 +10,8 @@ final class GetAreaViewController: BottomSheetController {
     
     // MARK: - Properties
     
+    var delegate: SaveSizeDelegate?
+    
     private let titleLabel: UILabel = {
         let title = UILabel()
         title.font = .systemFont(ofSize: 17, weight: .semibold)
@@ -103,6 +105,16 @@ final class GetAreaViewController: BottomSheetController {
     // MARK: - Func
 
     @objc func buttonDidTap() {
-        dismiss(animated: true)
+        save()
     }
+    
+    func save() {
+        dismiss(animated: true) {
+            self.delegate?.saveButtonTapped(widthString: self.getWidthView.textField.text ?? "", heightString: self.getHeightView.textField.text ?? "")
+        }
+    }
+}
+
+protocol SaveSizeDelegate {
+    func saveButtonTapped(widthString: String, heightString: String)
 }

--- a/Samplero/Samplero/Screen/TermsAndConditions/ViewModel/TermsViewModel.swift
+++ b/Samplero/Samplero/Screen/TermsAndConditions/ViewModel/TermsViewModel.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-import RxSwift
 import RxCocoa
+import RxSwift
 
 class TermsViewModel {
     var disposeBag = DisposeBag()


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #25 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
<img width="260" alt="image" src="https://user-images.githubusercontent.com/78426896/195758692-6f44065f-8a3f-4140-9aaf-50d96c8c9a14.gif" />

- 예상 면적을 입력하면 예상 가격과 수량을 계산해서 화면에 나타내도록 하였습니다.

## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
- 투명도 조절로 ToBeEstimatedPriceView와 EstimatedView를 바꿔서 보여줍니다. 더 좋은 방법이 생각이 안나요..
- 급하게 작성해서 조금 지저분 할 것 같습니다. 리뷰 주시면 최대한 빠르게 반영하겠습니다!

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 샘플 디테일 화면과 연결

