### PR TITLE
[UI] Shop Basket Terms View 연결

### DIFF
--- a/Samplero/Samplero/.swiftlint.yml
+++ b/Samplero/Samplero/.swiftlint.yml
@@ -23,5 +23,6 @@ disabled_rules:
     - identifier_name
     # 후행 공백 제한
     - trailing_whitespace
+    - function_body_length
 
 

--- a/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
@@ -352,24 +352,27 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
             .disposed(by: viewModel.disposeBag)
         
         viewModel.selectionState
-            .subscribe(onNext: { samples in
-                var copyString: String = ""
-                var number: Int = 0
-                for sample in samples {
-                    number += 1
-                    copyString += "\(number). \(sample.sample.maker) \(sample.sample.matName)\n"
-                }
-                self.viewModel.shopBasketCopy = copyString
-            })
-            .disposed(by: viewModel.disposeBag)
+                  .map({ samples in
+                      var copyString: String = ""
+                      var number: Int = 0
+                      for sample in samples {
+                          number += 1
+                          copyString += "\(number). \(sample.sample.maker) \(sample.sample.matName)\n"
+                      }
+                      return copyString
+                  })
+                  .bind(to: viewModel.shopBasketCopy)
+                  .disposed(by: viewModel.disposeBag)
+
+              orderButton.rx.tap
+                  .withLatestFrom(viewModel.shopBasketCopy.asObservable())
+                  .subscribe(onNext: {
+                      let vc = TermsViewController()
+                      vc.setShopBasketString(str: $0)
+                      self.navigationController?.pushViewController(vc, animated: true)
+                  })
+                  .disposed(by: viewModel.disposeBag)
         
-        orderButton.rx.tap
-            .subscribe(onNext: {
-                let vc = TermsViewController()
-                vc.setShopBasketString(str: self.viewModel.shopBasketCopy)
-                self.navigationController?.pushViewController(vc, animated: true)
-            })
-            .disposed(by: viewModel.disposeBag)
     }
     
     // MARK: - Func

--- a/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
@@ -73,7 +73,7 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
     private let orderButton: UIButton = {
         let button = UIButton()
         button.backgroundColor = .boxBackground
-        button.layer.cornerRadius = Size.orderButtonCorneradius
+        button.layer.cornerRadius = Size.orderButtonCorneRadius
         button.layer.zPosition = Size.zPositionValue
         button.isEnabled = false
         return button
@@ -85,6 +85,7 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
         view.axis = .vertical
         view.distribution = .fillEqually
         view.spacing = Size.buttonTextStackViewSpacing
+        view.isUserInteractionEnabled = false
         return view
     }()
     
@@ -179,17 +180,11 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
             make.trailing.equalToSuperview().inset(Size.defaultOffset)
         }
         
-        view.addSubview(orderButton)
-        orderButton.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(Size.defaultOffset)
-            make.bottom.equalTo(view.safeAreaLayoutGuide)
-            make.height.equalTo(Size.orderButtonHeight)
-        }
-        
         orderButton.addSubview(buttonTextStackView)
         buttonTextStackView.snp.makeConstraints { make in
             make.centerX.centerY.equalToSuperview()
         }
+        
         buttonTextStackView.addArrangedSubview(buttonFirstLabel)
         buttonTextStackView.addArrangedSubview(buttonSecondLabel)
         
@@ -197,6 +192,13 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
         shopBasketCollectionView.snp.makeConstraints { make in
             make.top.equalTo(allButtonsBackgroundView.snp.bottom)
             make.leading.bottom.trailing.equalToSuperview()
+        }
+        
+        view.addSubview(orderButton)
+        orderButton.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(Size.defaultOffset)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(Size.orderButtonHeight)
         }
         
         view.addSubview(noSampleLabel)

--- a/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
@@ -295,7 +295,7 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
         viewModel.selectionState
             .map { !$0.isEmpty }
             .asDriver(onErrorJustReturn: false)
-            .drive(orderButton.rx.enableStatus)
+            .drive(orderButton.rx.buttonEnabledStatus)
             .disposed(by: viewModel.disposeBag)
 
         // selectionState binding to allChoiceButton
@@ -407,7 +407,7 @@ extension Reactive where Base: UICollectionView {
 
 
 extension Reactive where Base: UIButton {
-    var enableStatus: Binder<Bool> {
+    var buttonEnabledStatus: Binder<Bool> {
         return Binder(self.base) { button, boolValue in
             switch boolValue {
             case true :

--- a/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
@@ -350,6 +350,26 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
                 }
             })
             .disposed(by: viewModel.disposeBag)
+        
+        viewModel.selectionState
+            .subscribe(onNext: { samples in
+                var copyString: String = ""
+                var number: Int = 0
+                for sample in samples {
+                    number += 1
+                    copyString += "\(number). \(sample.sample.maker) \(sample.sample.matName)\n"
+                }
+                self.viewModel.shopBasketCopy = copyString
+            })
+            .disposed(by: viewModel.disposeBag)
+        
+        orderButton.rx.tap
+            .subscribe(onNext: {
+                let vc = TermsViewController()
+                vc.setShopBasketString(str: self.viewModel.shopBasketCopy)
+                self.navigationController?.pushViewController(vc, animated: true)
+            })
+            .disposed(by: viewModel.disposeBag)
     }
     
     // MARK: - Func
@@ -415,7 +435,7 @@ extension Reactive where Base: UIButton {
                 button.backgroundColor = .accent
             case false :
                 button.isHidden = false
-                button.backgroundColor = .systemGray4
+                button.backgroundColor = .boxBackground
             }
         }
     }

--- a/Samplero/Samplero/Screen/ShopBasket/ViewModel/ShopBasketViewModel.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ViewModel/ShopBasketViewModel.swift
@@ -20,7 +20,8 @@ class ShopBasketViewModel {
 
 
     // MARK: - Properties
-
+    
+    var shopBasketCopy: String = ""
 
     var disposeBag: DisposeBag = DisposeBag()
     let wishedSampleRelay = BehaviorRelay<[CheckSample]>(value: MockData.sampleList.map {CheckSample(sample: $0)})

--- a/Samplero/Samplero/Screen/ShopBasket/ViewModel/ShopBasketViewModel.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ViewModel/ShopBasketViewModel.swift
@@ -21,7 +21,7 @@ class ShopBasketViewModel {
 
     // MARK: - Properties
     
-    var shopBasketCopy: String = ""
+    var shopBasketCopy = BehaviorSubject(value: "")
 
     var disposeBag: DisposeBag = DisposeBag()
     let wishedSampleRelay = BehaviorRelay<[CheckSample]>(value: MockData.sampleList.map {CheckSample(sample: $0)})

--- a/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
+++ b/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
@@ -29,6 +29,8 @@ class TermsViewController: BaseViewController {
     
     // MARK: - Properties
     
+    private var shopBasketString: String = ""
+    
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "샘플 발송을 위해 약관동의가 필요합니다."
@@ -112,6 +114,8 @@ class TermsViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        showToastAnimation()
+        
         bind()
     }
     
@@ -175,12 +179,15 @@ class TermsViewController: BaseViewController {
             .disposed(by: viewModel.disposeBag)
     }
     
+    func setShopBasketString(str: String) {
+        self.shopBasketString = str
+    }
+    
     @objc func buttonTapped() {
         if checkboxImageView.isChecked {
-//            showToastAnimation()
             
             // FIXME: - 테스트 용 string입니다. 추후 장바구니 내역으로 수정 필요
-            UIPasteboard.general.string = "장바구니 내역"
+            UIPasteboard.general.string = "장바구니 내역\n\(shopBasketString)"
             
             sleep(2)
             if let url = URL(string: "https://pf.kakao.com/_xalMTxj/chat") {


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #71 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
* ShopBasketViewController에서 주문하기 버튼을 누르면 TermsViewController로 넘어가도록 코드를 수정하였습니다.
* TermsViewController, ShopBasketViewController 모두 enableStatus가 있어 ShopBasketViewController의 enableStatus를 buttonEnableStatus로 변경하였습니다.
* ShopBasketViewController의 orderButton이 CollectionView뒤로 숨어 클릭이 되지 않는 문제가 있었습니다. CollectionView를 먼저 그리고 그 뒤에 button을 추가하고 button 내부에 있는 stackView의 isUserInteractionEnabled 설정을 false로 하여 해결하였습니다. 이때 왜 isUserInteractionEnabled를 false로 설정해야 하는지 정확한 이유는 모르나 다음 링크를 통해 참조하여 수정할 수 있었습니다. ![링크](https://stackoverflow.com/questions/60346261/uibutton-cant-click-after-adding-subviews)
* TermsViewController와 ShopBasketViewController의 화면을 연결하였습니다.
* 장바구니 내역을 가져와 복사할 문자열을 만들고 이를 TermsViewController로 넘겨주기 위해 ShopBasketViewModel에 shopBasketCopy를 추가하였습니다.
* 장바구니 내역을 가져와 복사할 문자열을 만들고 이를 TermsViewController에서 받기 위해 TermsViewController에 shopBasketString를 추가하고 setShopBasketString() 함수를 추가하였습니다. ShopBasketViewController에서 TermsViewController로 화면전환 시 해당문자열을 설정하도록 하였습니다.

__시연__

![video](https://user-images.githubusercontent.com/56468120/195806588-03d30c8e-e882-4bd0-8fbc-30af21ead98a.mov)


## ⁴/₄ PR 포인트
우린 대단해

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 

