### PR TITLE
[ADD] 장바구니 뷰에 divider 추가

### DIFF
--- a/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
@@ -115,7 +115,7 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         layout.minimumLineSpacing = Size.cellSpacing
-        layout.sectionInset = .init(top: 24, left: 0, bottom: 24, right: 24)
+        layout.sectionInset = .init(top: 24, left: 0, bottom: 24, right: 0)
         return layout
     }()
     

--- a/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
@@ -69,6 +69,12 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
         return button
     }()
     
+    private let upperDivider: UIView = {
+        let divider = UIView()
+        divider.backgroundColor = UIColor.separator
+        return divider
+    }()
+    
     // orderButton consists of buttonTextStackView( buttonFirstLabel, buttonSecondLabel )
     private let orderButton: UIButton = {
         let button = UIButton()
@@ -109,6 +115,7 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         layout.minimumLineSpacing = Size.cellSpacing
+        layout.sectionInset = .init(top: 24, left: 0, bottom: 24, right: 24)
         return layout
     }()
     
@@ -178,6 +185,14 @@ final class ShopBasketViewController: BaseViewController, ViewModelBindableType 
         allDeleteButton.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.trailing.equalToSuperview().inset(Size.defaultOffset)
+        }
+        
+        
+        view.addSubview(upperDivider)
+        upperDivider.snp.makeConstraints { make in
+            make.height.equalTo(1)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(allButtonsBackgroundView)
         }
         
         orderButton.addSubview(buttonTextStackView)

--- a/Samplero/Samplero/Screen/ShopBasket/View/AmountFooterView.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/View/AmountFooterView.swift
@@ -22,6 +22,11 @@ class AmountFooterView: UICollectionReusableView {
         return stackView
     }()
 
+    private let divider: UIView = {
+        let divider = UIView()
+        divider.backgroundColor = .separator
+        return divider
+    }()
     private let topSapcingView = UIView()
     private let totalPriceView = AmountStackView(detailName: "합계")
     private let deliveryFeeView = AmountStackView(detailName: "배송비")
@@ -51,6 +56,12 @@ class AmountFooterView: UICollectionReusableView {
             make.edges.equalToSuperview().inset(UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20))
 
         }
+        verticalStackView.addSubview(divider)
+        divider.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.height.equalTo(1)
+        }
+//
         verticalStackView.addArrangedSubview(topSapcingView)
         topSapcingView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #82 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
<img width="260" alt="image" src="https://user-images.githubusercontent.com/78426896/195867602-28bcc3de-0388-4322-9000-53aa4c8e553e.png" />

- 장바구니 뷰에 두 개의 divider를 추가했습니다.
- 이 간단한 걸 오래 해멨어요..ㅠ

## ⁴/₄ PR 포인트
<!-- 같이 고민하고 싶은 부분들을 작성해주세요. -->
<!-- 꼭 리뷰해주셔야 하는 분을 태그해주세요. -->
마지막까지 화이팅🔥

## ⁴/₄ 다음으로 진행될 작업
 - [ ] 다음으로 할 일을 적어주세요.

