### PR TITLE
[FEAT] 카메라 도움말 뷰 확인 버튼 추가

### DIFF
--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -16,6 +16,8 @@ class CameraViewController: BaseViewController {
     
     // MARK: - Properties
     
+    let isClosedHelpView: Bool = UserDefaults.standard.bool(forKey: "isClosedHelpView")
+    
     // Capture Session
     var session: AVCaptureSession?
     // Photo Output
@@ -192,6 +194,14 @@ class CameraViewController: BaseViewController {
         
         view.backgroundColor = .black
         navigationItem.backButtonTitle = "카메라"
+        
+        if isClosedHelpView {
+            topDrawer.isHidden = false
+            cameraHelpView.isHidden = true
+        } else {
+            topDrawer.isHidden = true
+            cameraHelpView.isHidden = false
+        }
     }
     
     func bind() {
@@ -267,6 +277,7 @@ class CameraViewController: BaseViewController {
             .subscribe(onNext: { [weak self] _ in
                 self?.cameraHelpView.isHidden = true
                 self?.topDrawer.isHidden = false
+                UserDefaults.standard.set(true, forKey: "isClosedHelpView")
             })
             .disposed(by: disposeBag)
     }

--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -263,7 +263,7 @@ class CameraViewController: BaseViewController {
             print("clicked cart")
         }.disposed(by: disposeBag)
         
-        cameraHelpView.rx.tapGesture
+        cameraHelpView.xMarkButton.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 self?.cameraHelpView.isHidden = true
                 self?.topDrawer.isHidden = false

--- a/Samplero/Samplero/Screen/Camera/View/CameraHelpView.swift
+++ b/Samplero/Samplero/Screen/Camera/View/CameraHelpView.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 import SnapKit
+import RxCocoa
+import RxSwift
 
 class CameraHelpView: UIView {
 
@@ -71,6 +73,16 @@ class CameraHelpView: UIView {
         return label
     }()
     
+    let xMarkButton: UIButton = {
+        let button: UIButton = UIButton()
+        button.setTitle("확인", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.backgroundColor = .white
+        button.layer.masksToBounds = true
+        button.layer.cornerRadius = 23
+        return button
+    }()
+    
     // MARK: - Init
     
     override init(frame: CGRect) {
@@ -125,6 +137,14 @@ class CameraHelpView: UIView {
             make.top.equalToSuperview().inset(UIScreen.main.bounds.height / 5.55 - 4)
             make.bottom.equalTo(getLibraryPhotoMarkLabel.snp.top).offset(-4)
             make.centerX.equalToSuperview()
+        }
+        
+        addSubview(xMarkButton)
+        xMarkButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(couchMarkGuideLabel.snp.bottom).offset(10)
+            make.height.equalTo(46)
+            make.width.equalTo(90)
         }
     }
     

--- a/Samplero/Samplero/Screen/EstimateHistory/EstimateHistoryViewController.swift
+++ b/Samplero/Samplero/Screen/EstimateHistory/EstimateHistoryViewController.swift
@@ -76,6 +76,7 @@ class EstimateHistoryViewController: BaseViewController, ViewModelBindableType {
     }
     
     override func configUI() {
+        view.backgroundColor = .white
         navigationItem.title = "견적 내역"
     }
     


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #90 

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
* 도움말 뷰에 도움말 뷰를 지우는 확인 버튼을 추가
* 도움말 뷰를 한번 지우면 다시 앱을 실행했을 때는 도움말 뷰가 보이지 않도록 설저
