### PR TITLE
[REFACTOR] restrict ACL reactive extension #130

### DIFF
--- a/Samplero/Samplero/Screen/Camera/CameraViewController.swift
+++ b/Samplero/Samplero/Screen/Camera/CameraViewController.swift
@@ -487,23 +487,14 @@ extension CameraViewController: AVCapturePhotoCaptureDelegate {
 }
 
 extension Reactive where Base: TakenPictureViewController {
-    var retake: ControlEvent<Void> {
+    fileprivate var retake: ControlEvent<Void> {
         let source = self.base.getRetakeButton().rx.tap
         return ControlEvent(events: source)
     }
 
-    var nextButton: ControlEvent<Void> {
+    fileprivate var nextButton: ControlEvent<Void> {
         let source = self.base.getNextButton().rx.tap
         return ControlEvent(events: source)
-    }
-}
-
-extension Reactive where Base: UIView {
-    public var tapGesture : ControlEvent<UITapGestureRecognizer> {
-        self.base.isUserInteractionEnabled = true
-        let gesture = UITapGestureRecognizer()
-        self.base.addGestureRecognizer(gesture)
-        return gesture.rx.event
     }
 }
 

--- a/Samplero/Samplero/Screen/Estimate/EstimateViewController.swift
+++ b/Samplero/Samplero/Screen/Estimate/EstimateViewController.swift
@@ -373,3 +373,11 @@ final class EstimateViewController: BaseViewController, ViewModelBindableType {
 
 }
 
+extension Reactive where Base: UIView {
+    fileprivate var tapGesture: ControlEvent<UITapGestureRecognizer> {
+        self.base.isUserInteractionEnabled = true
+        let gesture = UITapGestureRecognizer()
+        self.base.addGestureRecognizer(gesture)
+        return gesture.rx.event
+    }
+}

--- a/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
+++ b/Samplero/Samplero/Screen/ShopBasket/ShopBasketViewController.swift
@@ -377,7 +377,7 @@ extension ShopBasketViewController: UICollectionViewDelegateFlowLayout {
 
 
 extension Reactive where Base: UICollectionView {
-    var visibleStatus: Binder<Bool> {
+    fileprivate var visibleStatus: Binder<Bool> {
         return Binder(self.base) { collectionView, boolValue in
             switch boolValue {
             case true :
@@ -393,7 +393,7 @@ extension Reactive where Base: UICollectionView {
 // MARK: - UIButton visibleStatus + Rx
 
 extension Reactive where Base: UIButton {
-    var buttonEnabledStatus: Binder<Bool> {
+    fileprivate var buttonEnabledStatus: Binder<Bool> {
         return Binder(self.base) { button, boolValue in
             switch boolValue {
             case true :

--- a/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
+++ b/Samplero/Samplero/Screen/TermsAndConditions/View/TermsViewController.swift
@@ -236,7 +236,7 @@ class TermsViewController: BaseViewController {
 }
 
 extension Reactive where Base: UIButton {
-    var enableStatus: Binder<Bool> {
+    fileprivate var enableStatus: Binder<Bool> {
         return Binder(self.base) { button, boolValue in
             switch boolValue {
             case true :


### PR DESCRIPTION
## ⁴/₄ 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- #130

## ⁴/₄ 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- Reactive extension에서 사용하는 프로퍼티는 그 파일에서만 활용하기 때문에 `internal` 에서 `fileprivate`으로 접근제한을 강화시켜주었습니다.